### PR TITLE
Change datadir to /var/lib/redis/data

### DIFF
--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -1,9 +1,9 @@
 FROM centos:centos7
 
-# Redis image for OpenShift.
+# Redis image based on Software Collections packages
 #
 # Volumes:
-#  * /var/lib/redis - Datastore for Redis
+#  * /var/lib/redis/data - Datastore for Redis
 # Environment:
 #  * $REDIS_PASSWORD - Database password
 
@@ -35,7 +35,7 @@ RUN yum install -y yum-utils gettext && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS --nogpgcheck && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \
-    mkdir -p /var/lib/redis && chown -R redis.0 /var/lib/redis
+    mkdir -p /var/lib/redis/data && chown -R redis.0 /var/lib/redis
 
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/redis \
@@ -56,7 +56,7 @@ ADD root /
 # script.
 RUN /usr/libexec/container-setup
 
-VOLUME ["/var/lib/redis"]
+VOLUME ["/var/lib/redis/data"]
 
 USER 1001
 

--- a/3.2/Dockerfile.rhel7
+++ b/3.2/Dockerfile.rhel7
@@ -1,9 +1,9 @@
 FROM rhel7:7.2
 
-# Redis image for OpenShift.
+# Redis image based on Software Collections packages
 #
 # Volumes:
-#  * /var/lib/redis - Datastore for Redis
+#  * /var/lib/redis/data - Datastore for Redis
 # Environment:
 #  * $REDIS_PASSWORD - Database password
 
@@ -26,6 +26,7 @@ LABEL BZComponent="rh-redis32-docker" \
 EXPOSE 6379
 
 # Create user for redis that has known UID
+# We need to do this before installing the RPMs which would create user with random UID
 RUN getent group  redis &> /dev/null || groupadd -r redis &> /dev/null && \
     getent passwd redis &> /dev/null || useradd -u 1001 -r -g redis -d $HOME -s /sbin/nologin \
            -c 'Redis Server' redis &> /dev/null
@@ -41,7 +42,7 @@ RUN yum install -y yum-utils gettext && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \
-    mkdir -p /var/lib/redis && chown -R redis.0 /var/lib/redis
+    mkdir -p /var/lib/redis/data && chown -R redis.0 /var/lib/redis
 
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/redis \
@@ -62,7 +63,7 @@ ADD root /
 # script.
 RUN /usr/libexec/container-setup
 
-VOLUME ["/var/lib/redis"]
+VOLUME ["/var/lib/redis/data"]
 
 USER 1001
 

--- a/3.2/README.md
+++ b/3.2/README.md
@@ -10,9 +10,13 @@ Dockerfile.rhel7.
 Environment variables and volumes
 ----------------------------------
 
+|    Variable name       |    Description                            |
+| :--------------------- | ----------------------------------------- |
+|  `REDIS_PASSWORD`      | Password for the server access            |
+
 TBD
 
-You can also set the following mount points by passing the `-v /host:/container` flag to Docker.
+You can also set the following mount points by passing the `-v /host:/container:Z` flag to Docker.
 
 |  Volume mount point      | Description          |
 | :----------------------- | -------------------- |
@@ -34,7 +38,18 @@ $ docker run -d --name redis_database 6379:6379 rhscl/redis-32-rhel7
 ```
 
 This will create a container named `redis_database`. Port 6379 will be exposed and mapped
-to the host. If you want your database to be persistent across container executions,
-also add a `-v /host/db/path:/var/lib/redis` argument. This will be the Redis
-data directory.
+to the host.
 
+If you want your database to be persistent across container executions, also add a
+`-v /host/db/path:/var/lib/redis/data:Z` argument. This will be the Redis data directory.
+
+For protecting Redis data by a password, pass `REDIS_PASSWORD` environment variable
+to the container like this:
+
+```
+$ docker run -d --name redis_database -e REDIS_PASSWORD=strongpassword rhscl/redis-32-rhel7
+```
+
+**Warning: since Redis is pretty fast an outside user can try up to
+150k passwords per second against a good box. This means that you should
+use a very strong password otherwise it will be very easy to break.**

--- a/3.2/root/usr/bin/run-redis
+++ b/3.2/root/usr/bin/run-redis
@@ -22,6 +22,6 @@ fi
 
 # Restart the Redis server with public IP bindings
 unset_env_vars
-log_volume_info $REDIS_DATADIR
+log_volume_info "${REDIS_DATADIR}"
 log_info 'Running final exec -- Only Redis logs after this point'
 exec ${REDIS_PREFIX}/bin/redis-server /etc/redis.conf --daemonize no "$@" 2>&1

--- a/3.2/root/usr/libexec/container-setup
+++ b/3.2/root/usr/libexec/container-setup
@@ -1,17 +1,20 @@
 #!/bin/bash
 
+source ${CONTAINER_SCRIPTS_PATH}/common.sh
+set -eu
+
 # setup config file
 mv /etc/opt/rh/rh-redis32/redis.conf /etc/redis.conf
 ln -s /etc/redis.conf /etc/opt/rh/rh-redis32/redis.conf
 
 # setup directory for data
-mkdir -p /var/lib/redis
-chown -R redis:0 /var/lib/redis /etc/redis.conf
-restorecon -R /var/lib/redis /etc/redis.conf
+chown -R redis:0 "${HOME}" /etc/redis.conf
+restorecon -R "${HOME}" /etc/redis.conf
 
 # Loosen permission bits for group to avoid problems running container with
 # arbitrary UID
 # When only specifying user, group is 0, that's why /var/lib/redis must have
 # owner redis.0; that allows to avoid a+rwx for this dir
-chmod g+w -R /var/lib/redis /etc/redis.conf
+chmod 0770 "${HOME}" "${REDIS_DATADIR}"
+chmod 0660 /etc/redis.conf
 

--- a/3.2/root/usr/share/container-scripts/redis/common.sh
+++ b/3.2/root/usr/share/container-scripts/redis/common.sh
@@ -3,9 +3,9 @@
 source ${CONTAINER_SCRIPTS_PATH}/helpers.sh
 
 # Data directory where MySQL database files live. The data subdirectory is here
-# because .bashrc and my.cnf both live in /var/lib/mysql/ and we don't want a
+# because .bashrc lives in /var/lib/mysql/ and we don't want a
 # volume to override it.
-export REDIS_DATADIR=/var/lib/redis
+export REDIS_DATADIR=/var/lib/redis/data
 
 # Be paranoid and stricter than we should be.
 redis_password_regex='^[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]+$'

--- a/3.2/test/run
+++ b/3.2/test/run
@@ -120,13 +120,13 @@ function run_change_password_test() {
 
   # Create Redis container with persistent volume and set the initial password
   create_container "testpass1" -e REDIS_PASSWORD=foo \
-    -e REDIS_DATABASE=db -v ${tmpdir}:/var/lib/redis:Z
+    -v ${tmpdir}:/var/lib/redis/data:Z
   test_connection testpass1 foo
   docker stop $(get_cid testpass1) >/dev/null
 
   # Create second container with changed password
   create_container "testpass2" -e REDIS_PASSWORD=bar \
-    -e REDIS_DATABASE=db -v ${tmpdir}:/var/lib/redis:Z
+    -v ${tmpdir}:/var/lib/redis/data:Z
   test_connection testpass2 bar
 
   # The old password should not work anymore


### PR DESCRIPTION
It is better, so .bashrc is not overwritten when mounting a volume
and datadir is not spoiled by any other files that might be stored
into redis' home dir that is /var/lib/redis.

This update also enhances documentation.