### PR TITLE
Protected mode

### DIFF
--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -32,7 +32,7 @@ RUN yum install -y yum-utils gettext && \
     yum install -y centos-release-scl && \
     yum-config-manager --enable centos-sclo-rh-testing && \
     INSTALL_PKGS="rh-redis32" && \
-    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    yum install -y --setopt=tsflags=nodocs --nogpgcheck $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \
     mkdir -p /var/lib/redis/data && chown -R redis.0 /var/lib/redis

--- a/3.2/root/usr/bin/run-redis
+++ b/3.2/root/usr/bin/run-redis
@@ -10,6 +10,8 @@ set -eu
 log_info 'Processing Redis configuration files ...'
 if [[ -v REDIS_PASSWORD ]]; then
   envsubst < ${CONTAINER_SCRIPTS_PATH}/password.conf.template >> /etc/redis.conf
+else
+  log_info 'WARNING: setting REDIS_PASSWORD is recommended'
 fi
 
 # Source post-init source if exists

--- a/3.2/root/usr/share/container-scripts/redis/common.sh
+++ b/3.2/root/usr/share/container-scripts/redis/common.sh
@@ -18,8 +18,9 @@ function unset_env_vars() {
 
 # Comment out settings that we'll set in container specifically
 function clear_config() {
-  t=$(mktemp /tmp/XXXXXXXX)
-  cat /etc/redis.conf | sed -e "s/^bind/#bind/" -e "s/^logfile/#logfile/" -e "s/^dir /#dir /" >$t
-  cp $t /etc/redis.conf
-  rm -f $t
+  sed -e "s/^bind/#bind/" \
+      -e "s/^logfile/#logfile/" \
+      -e "s/^dir /#dir /" \
+      -e "/^protected-mode/s/yes/no/" \
+      -i /etc/redis.conf
 }


### PR DESCRIPTION
Seems required to connect from outside the container when no password is set, to avoid:

```
$ redis-cli 
127.0.0.1:6379> info
DENIED Redis is running in protected mode because protected mode is enabled, no bind address was
specified, no authentication password is requested to clients. In this mode connections are only accepted
from the loopback interface. If you want to connect from external computers to Redis you may adopt one of
the following solutions: 
1) Just disable protected mode sending the command 'CONFIG SET protected-mode no' from the loopback
interface by connecting to Redis from the same host the server is running, however MAKE SURE Redis is
not publicly accessible from internet if you do so. Use CONFIG REWRITE to make this change permanent. 
2) Alternatively you can just disable the protected mode by editing the Redis configuration file, and setting the
protected mode option to 'no', and then restarting the server.
3) If you started the server manually just for testing, restart it with the '--protected-mode no' option.
4) Setup a bind address or an authentication password. NOTE: You only need to do one of the above things
in order for the server to start accepting connections from the outside.
```