### PR TITLE
Fix assert_local_access test

### DIFF
--- a/3.2/test/run
+++ b/3.2/test/run
@@ -165,7 +165,7 @@ function assert_login_access() {
 
 function assert_local_access() {
   local id="$1" ; shift
-  docker exec $(get_cid "$id") bash -c redis-cli ping
+  docker exec $(get_cid "$id") bash -c 'redis-cli ping'
 }
 
 # Make sure the invocation of docker run fails.


### PR DESCRIPTION
After upgrade from docker 1.10 to docker 1.12 `assert_local_access` test started to fail.

So `docker exec $(get_cid "$id") bash -c redis-cli ping` is waiting forever. Quotes or -i is required to make test passing.
