### PR TITLE
Update Dockerfiles

### DIFF
--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -24,7 +24,11 @@ LABEL summary="$SUMMARY" \
       io.k8s.description="$SUMMARY" \
       io.k8s.display-name="Redis 3.2" \
       io.openshift.expose-services="6379:redis" \
-      io.openshift.tags="database,redis,redis32,rh-redis32"
+      io.openshift.tags="database,redis,redis32,rh-redis32" \
+      com.redhat.component="rh-redis32-docker" \
+      name="centos/redis-32-centos7" \
+      version="3.2" \
+      release="1"
 
 EXPOSE 6379
 
@@ -59,7 +63,7 @@ ENV BASH_ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
     ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
     PROMPT_COMMAND=". ${CONTAINER_SCRIPTS_PATH}/scl_enable"
 
-ADD root /
+COPY root /
 
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup

--- a/3.2/Dockerfile.fedora
+++ b/3.2/Dockerfile.fedora
@@ -11,7 +11,8 @@ ENV NAME=redis \
     VERSION=3.2 \
     RELEASE=1 \
     ARCH=x86_64
-    REDIS_VERSION=$VERSION \
+
+ENV REDIS_VERSION=$VERSION \
     HOME=/var/lib/redis
 
 ENV SUMMARY="Redis in-memory data structure store, used as database, cache and message broker" \
@@ -29,7 +30,7 @@ LABEL summary="$SUMMARY" \
       io.k8s.display-name="Redis 3.2" \
       io.openshift.expose-services="6379:redis" \
       io.openshift.tags="database,redis,redis32,rh-redis32" \
-      com.redhat.component ="$NAME" \
+      com.redhat.component="$NAME" \
       name="$FGC/$NAME" \
       version="$VERSION" \
       release="$RELEASE.$DISTTAG" \

--- a/3.2/Dockerfile.fedora
+++ b/3.2/Dockerfile.fedora
@@ -11,14 +11,7 @@ ENV NAME=redis \
     VERSION=3.2 \
     RELEASE=1 \
     ARCH=x86_64
-
-LABEL BZComponent="$NAME" \
-      Name="$FGC/$NAME" \
-      Version="$VERSION" \
-      Release="$RELEASE.$DISTTAG" \
-      Architecture="$ARCH"
-
-ENV REDIS_VERSION=$VERSION \
+    REDIS_VERSION=$VERSION \
     HOME=/var/lib/redis
 
 ENV SUMMARY="Redis in-memory data structure store, used as database, cache and message broker" \
@@ -35,7 +28,12 @@ LABEL summary="$SUMMARY" \
       io.k8s.description="$SUMMARY" \
       io.k8s.display-name="Redis 3.2" \
       io.openshift.expose-services="6379:redis" \
-      io.openshift.tags="database,redis,redis32,rh-redis32"
+      io.openshift.tags="database,redis,redis32,rh-redis32" \
+      com.redhat.component ="$NAME" \
+      name="$FGC/$NAME" \
+      version="$VERSION" \
+      release="$RELEASE.$DISTTAG" \
+      architecture="$ARCH"
 
 EXPOSE 6379
 
@@ -60,7 +58,7 @@ RUN dnf install -y yum-utils gettext policycoreutils && \
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/redis \
     REDIS_PREFIX=/usr
 
-ADD root /
+COPY root /
 
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup

--- a/3.2/Dockerfile.rhel7
+++ b/3.2/Dockerfile.rhel7
@@ -24,14 +24,11 @@ LABEL summary="$SUMMARY" \
       io.k8s.description="$SUMMARY" \
       io.k8s.display-name="Redis 3.2" \
       io.openshift.expose-services="6379:redis" \
-      io.openshift.tags="database,redis,redis32,rh-redis32"
-
-# Labels consumed by Red Hat build service
-LABEL com.redhat.component="rh-redis32-docker" \
+      io.openshift.tags="database,redis,redis32,rh-redis32" \
+      com.redhat.component="rh-redis32-docker" \
       name="rhscl/redis-32-rhel7" \
       version="3.2" \
-      release="1" \
-      architecture="x86_64"
+      release="1"
 
 EXPOSE 6379
 
@@ -66,7 +63,7 @@ ENV BASH_ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
     ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
     PROMPT_COMMAND=". ${CONTAINER_SCRIPTS_PATH}/scl_enable"
 
-ADD root /
+COPY root /
 
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup


### PR DESCRIPTION
Use COPY instruction instead of ADD
(COPY is preffered for simple usage - see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#add-or-copy)
    
Provide same labels for all base image variants (CentOS, RHEL, Fedora)
 - follow recomended labels from Project Atomic Container best practices
 - add summary and description labels (Fedora requirements) - use ENV for simple using of same value in more descriptive labels
 - use lower-case variants of Fedora labels
 - remove architecture label for RHEL based images (this label is set in RHEL image - no need to define it again)
    
(don't use separate instruction for each label)

@hhorak @praiskup @pkubatrh Please take a look and merge.