### PR TITLE
Various small documentation related changes

### DIFF
--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -28,7 +28,8 @@ LABEL summary="$SUMMARY" \
       com.redhat.component="rh-redis32-docker" \
       name="centos/redis-32-centos7" \
       version="3.2" \
-      release="1"
+      usage="docker run -d --name redis_database -p 6379:6379 centos/redis-32-centos7" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 6379
 

--- a/3.2/Dockerfile.fedora
+++ b/3.2/Dockerfile.fedora
@@ -35,6 +35,8 @@ LABEL summary="$SUMMARY" \
       version="$VERSION" \
       release="$RELEASE.$DISTTAG" \
       architecture="$ARCH"
+      usage="docker run -d --name redis_database -p 6379:6379 $FGC/$NAME" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 6379
 

--- a/3.2/Dockerfile.rhel7
+++ b/3.2/Dockerfile.rhel7
@@ -28,7 +28,8 @@ LABEL summary="$SUMMARY" \
       com.redhat.component="rh-redis32-docker" \
       name="rhscl/redis-32-rhel7" \
       version="3.2" \
-      release="1"
+      usage="docker run -d --name redis_database -p 6379:6379 rhscl/redis-32-rhel7" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 6379
 

--- a/3.2/root/usr/bin/usage
+++ b/3.2/root/usr/bin/usage
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cat /usr/share/container-scripts/redis/README.md
+

--- a/3.2/root/usr/share/container-scripts/redis/README.md
+++ b/3.2/root/usr/share/container-scripts/redis/README.md
@@ -53,15 +53,15 @@ use a very strong password otherwise it will be very easy to break.**
 Environment variables and volumes
 ----------------------------------
 
-|    Variable name       |    Description                            |
-| :--------------------- | ----------------------------------------- |
-|  `REDIS_PASSWORD`      | Password for the server access            |
+**`REDIS_PASSWORD`**  
+       Password for the server access
+
 
 You can also set the following mount points by passing the `-v /host:/container:Z` flag to Docker.
 
-|  Volume mount point      | Description          |
-| :----------------------- | -------------------- |
-|  `/var/lib/redis/data`   | Redis data directory |
+**`/var/lib/redis/data`**  
+       Redis data directory
+
 
 **Notice: When mouting a directory from the host into the container, ensure that the mounted
 directory has the appropriate permissions and that the owner and group of the directory

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Redis Docker image
 ==================
 
 This repository contains Dockerfiles for Redis Docker image.
-Users can choose between RHEL and CentOS based images.
+Users can choose between RHEL, Fedora and CentOS based images.
 
 For more information about contributing, see
 [the Contribution Guidelines](https://github.com/sclorg/welcome/blob/master/contribution.md).
@@ -27,7 +27,8 @@ Installation
 To build a Redis image, choose either the CentOS or RHEL based image:
 *  **RHEL based image**
 
-    This image is available in Red Hat Container Registry. To download it run:
+    These images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/#/registry.access.redhat.com/rhscl/redis-32-rhel7).
+    To download it run:
 
     ```
     $ docker pull registry.access.redhat.com/rhscl/redis-32-rhel7
@@ -68,7 +69,7 @@ Usage
 ---------------------------------
 
 For information about usage of Dockerfile for Redis 3.2,
-see [usage documentation](3.2/README.md).
+see [usage documentation](3.2).
 
 Test
 ---------------------


### PR DESCRIPTION
Use maintainer label consistently
Few edits in top-level README
Using usage label and command
Remove tables in README, because go-md2man cannot convert them properly