### PR TITLE
Use released repos only

### DIFF
--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -43,7 +43,6 @@ RUN getent group  redis &> /dev/null || groupadd -r redis &> /dev/null && \
 # to make sure of that.
     yum install -y yum-utils gettext && \
     yum install -y centos-release-scl && \
-    yum-config-manager --enable centos-sclo-rh-testing && \
     INSTALL_PKGS="rh-redis32" && \
     yum install -y --setopt=tsflags=nodocs --nogpgcheck $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \


### PR DESCRIPTION
It is not necessary to use testing repo now anymore, all packages are in released repo already.