### PR TITLE
Removing Version Typo from Image Stream Descriptions

### DIFF
--- a/imagestreams/redis-centos7.json
+++ b/imagestreams/redis-centos7.json
@@ -11,7 +11,7 @@
     "tags": [
       {
         "annotations": {
-          "description": "Provides a Redis database on CentOS 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/redis-container/tree/master/3.2/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Redis available on OpenShift, including major versions updates.",
+          "description": "Provides a Redis database on CentOS 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/redis-container/tree/master/3.2/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Redis available on OpenShift, including major version updates.",
           "iconClass": "icon-redis",
           "openshift.io/display-name": "Redis (Latest)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",

--- a/imagestreams/redis-rhel7.json
+++ b/imagestreams/redis-rhel7.json
@@ -11,7 +11,7 @@
     "tags": [
       {
         "annotations": {
-          "description": "Provides a Redis database on RHEL 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/redis-container/tree/master/3.2/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Redis available on OpenShift, including major versions updates.",
+          "description": "Provides a Redis database on RHEL 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/redis-container/tree/master/3.2/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Redis available on OpenShift, including major version updates.",
           "iconClass": "icon-redis",
           "openshift.io/display-name": "Redis (Latest)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",


### PR DESCRIPTION
This pull request removes a minor typo for all the image stream descriptions.