### PR TITLE
Use refactored functions and enable testing in remote OCP4

### DIFF
--- a/test/run-openshift-local-cluster
+++ b/test/run-openshift-local-cluster
@@ -11,10 +11,13 @@ THISDIR=$(dirname ${BASH_SOURCE[0]})
 source "$THISDIR"/test-lib-openshift.sh
 source ${THISDIR}/test-lib-redis.sh
 
-set -exo nounset
+set -eo nounset
 
-test -n "${IMAGE_NAME-}" || false 'make sure $IMAGE_NAME is defined'
-test -n "${VERSION-}" || false 'make sure $VERSION is defined'
+trap ct_os_cleanup EXIT SIGINT
+
+ct_os_check_compulsory_vars
+
+ct_os_enable_print_logs
 
 function check_redis_os_service_connection() {
   local util_image_name=$1 ; shift
@@ -97,16 +100,20 @@ test_redis_integration "${IMAGE_NAME}" "${VERSION}" redis
 # test with a released image and an integrated template
 PUBLIC_IMAGE_NAME=$(ct_get_public_image_name "$OS" "$BASE_IMAGE_NAME" "$VERSION")
 
-export CT_SKIP_UPLOAD_IMAGE=true
 # Try pulling the image first to see if it is accessible
 if ct_check_image_availability "$PUBLIC_IMAGE_NAME"; then
-  test_redis_integration redis "${VERSION}" "${PUBLIC_IMAGE_NAME}"
+  test_redis_integration "${PUBLIC_IMAGE_NAME}" "${VERSION}" redis
 else
   # Do not fail on centos7 as it the image might be in the process of being added
   [ "$OS" == "centos7" ] || false "ERROR: Failed to pull image"
 fi
 
+# Check the imagestream
+test_redis_imagestream
+
 OS_TESTSUITE_RESULT=0
 
 ct_os_cluster_down
+
+# vim: set tabstop=2:shiftwidth=2:expandtab:
 

--- a/test/run-openshift-local-cluster
+++ b/test/run-openshift-local-cluster
@@ -95,17 +95,18 @@ test_redis_pure_image "${IMAGE_NAME}"
 test_redis_template "${IMAGE_NAME}"
 
 # test with the just built image and an integrated template
-test_redis_integration "${IMAGE_NAME}" "${VERSION}" redis
+test_redis_integration "${IMAGE_NAME}"
 
 # test with a released image and an integrated template
-PUBLIC_IMAGE_NAME=$(ct_get_public_image_name "$OS" "$BASE_IMAGE_NAME" "$VERSION")
+PUBLIC_IMAGE_NAME=${PUBLIC_IMAGE_NAME:-$(ct_get_public_image_name "${OS}" "${BASE_IMAGE_NAME}" "${VERSION}")}
 
 # Try pulling the image first to see if it is accessible
 if ct_check_image_availability "$PUBLIC_IMAGE_NAME"; then
-  test_redis_integration "${PUBLIC_IMAGE_NAME}" "${VERSION}" redis
+  test_redis_integration "${PUBLIC_IMAGE_NAME}"
 else
-  # Do not fail on centos7 as it the image might be in the process of being added
-  [ "$OS" == "centos7" ] || false "ERROR: Failed to pull image"
+  echo "Warning: ${PUBLIC_IMAGE_NAME} could not be downloaded via 'docker'"
+  # ignore possible failure of this test for centos images
+  [ "${OS}" == "rhel7" ] && false "ERROR: Failed to pull image"
 fi
 
 # Check the imagestream

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -24,7 +24,13 @@ export CT_SKIP_NEW_PROJECT=true
 export CT_SKIP_UPLOAD_IMAGE=true
 export CT_NAMESPACE=openshift
 
-test_redis_integration redis ${VERSION} "${IMAGE_NAME}"
+# Check the template
+test_redis_integration "${IMAGE_NAME}" ${VERSION} redis
+
+# Check the imagestream
+test_redis_imagestream
 
 OS_TESTSUITE_RESULT=0
+
+# vim: set tabstop=2:shiftwidth=2:expandtab:
 

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -25,7 +25,7 @@ export CT_SKIP_UPLOAD_IMAGE=true
 export CT_NAMESPACE=openshift
 
 # Check the template
-test_redis_integration "${IMAGE_NAME}" ${VERSION} redis
+test_redis_integration "${IMAGE_NAME}"
 
 # Check the imagestream
 test_redis_imagestream

--- a/test/test-lib-redis.sh
+++ b/test/test-lib-redis.sh
@@ -13,9 +13,7 @@ source ${THISDIR}/test-lib-openshift.sh
 
 function test_redis_integration() {
   local image_name=$1
-  local VERSION=$2
-  local service_name=$3
-  local image_tagged="${service_name}:${VERSION}"
+  local service_name=redis
   ct_os_test_template_app_func "${image_name}" \
                                "https://raw.githubusercontent.com/openshift/origin/master/examples/db-templates/redis-ephemeral-template.json" \
                                "${service_name}" \

--- a/test/test-lib-redis.sh
+++ b/test/test-lib-redis.sh
@@ -14,15 +14,25 @@ source ${THISDIR}/test-lib-openshift.sh
 function test_redis_integration() {
   local image_name=$1
   local VERSION=$2
-  local import_image=$3
-  local service_name=${import_image##*/}
+  local service_name=$3
+  local image_tagged="${service_name}:${VERSION}"
   ct_os_test_template_app_func "${image_name}" \
                                "https://raw.githubusercontent.com/openshift/origin/master/examples/db-templates/redis-ephemeral-template.json" \
                                "${service_name}" \
-                               "ct_os_check_cmd_internal '${import_image}' '${service_name}' 'timeout 15 redis-cli -h <IP> -a testp ping' 'PONG'" \
+                               "ct_os_check_cmd_internal '<SAME_IMAGE>' '${service_name}-testing' 'timeout 15 redis-cli -h <IP> -a testp ping' 'PONG'" \
                                "-p REDIS_VERSION=${VERSION} \
                                 -p DATABASE_SERVICE_NAME="${service_name}-testing" \
-                                -p REDIS_PASSWORD=testp" "" "${import_image}"
+                                -p REDIS_PASSWORD=testp"
+}
+
+# Check the imagestream
+function test_redis_imagestream() {
+  case ${OS} in
+    rhel7|centos7) ;;
+    *) echo "Imagestream testing not supported for $OS environment." ; return 0 ;;
+  esac
+
+  ct_os_test_image_stream_template "${THISDIR}/../imagestreams/redis-${OS}.json" "${THISDIR}/../examples/redis-ephemeral-template.json" redis "-p REDIS_VERSION=${VERSION}"
 }
 
 # vim: set tabstop=2:shiftwidth=2:expandtab:


### PR DESCRIPTION
This PR combines more changes:

- add image stream test
- adopts new functions refactored in https://github.com/sclorg/container-common-scripts/pull/155/files
- enables tests to be run in a remote OCP4 cluster
