### PR TITLE
Append "redis" group rather than making it exclusive

### DIFF
--- a/5/Dockerfile
+++ b/5/Dockerfile
@@ -36,7 +36,7 @@ EXPOSE 6379
 # Create user for redis that has known UID
 # We need to do this before installing the RPMs which would create user with random UID
 RUN getent group  redis &> /dev/null || groupadd -r redis &> /dev/null && \
-    usermod -l redis -g redis -c 'Redis Server' default &> /dev/null && \
+    usermod -l redis -aG redis -c 'Redis Server' default &> /dev/null && \
 # Install gettext for envsubst command
 # This image must forever use UID 964 for redis user so our volumes are
 # safe in the future. This should *never* change, the last test is there

--- a/5/Dockerfile.fedora
+++ b/5/Dockerfile.fedora
@@ -43,7 +43,7 @@ EXPOSE 6379
 # Create user for redis that has known UID
 # We need to do this before installing the RPMs which would create user with random UID
 RUN getent group  redis &> /dev/null || groupadd -r redis &> /dev/null && \
-    usermod -l redis -g redis -c 'Redis Server' default &> /dev/null && \
+    usermod -l redis -aG redis -c 'Redis Server' default &> /dev/null && \
 # Install gettext for envsubst command
 # This image must forever use UID 964 for redis user so our volumes are
 # safe in the future. This should *never* change, the last test is there

--- a/5/Dockerfile.rhel7
+++ b/5/Dockerfile.rhel7
@@ -37,7 +37,7 @@ EXPOSE 6379
 # Create user for redis that has known UID
 # We need to do this before installing the RPMs which would create user with random UID
 RUN getent group  redis &> /dev/null || groupadd -r redis &> /dev/null && \
-    usermod -l redis -g redis -c 'Redis Server' default &> /dev/null && \
+    usermod -l redis -aG redis -c 'Redis Server' default &> /dev/null && \
 # Install gettext for envsubst command
 # This image must forever use UID 964 for redis user so our volumes are
 # safe in the future. This should *never* change, the last test is there

--- a/5/Dockerfile.rhel8
+++ b/5/Dockerfile.rhel8
@@ -37,7 +37,7 @@ EXPOSE 6379
 # Create user for redis that has known UID
 # We need to do this before installing the RPMs which would create user with random UID
 RUN getent group  redis &> /dev/null || groupadd -r redis &> /dev/null && \
-    usermod -l redis -g redis -c 'Redis Server' default &> /dev/null && \
+    usermod -l redis -aG redis -c 'Redis Server' default &> /dev/null && \
 # Install gettext for envsubst command
 # This image must forever use UID 964 for redis user so our volumes are
 # safe in the future. This should *never* change, the last test is there


### PR DESCRIPTION
In our environment, we have a redis sidecar container in each of our pods, using a unix domain socket shared amongst multiple containers.

To deal with the arbitrary UID problem, we typically give +rw access to the "root" group. However, we ran into issues with the Redis container, since the user only belongs to the "redis" group. This PR fixes that problem for us.