### PR TITLE
Support redis-container on Quay.io

### DIFF
--- a/5/Dockerfile
+++ b/5/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos/s2i-core-centos7
+FROM quay.io/centos7/s2i-core-centos7
 
 # Redis image based on Software Collections packages
 #
@@ -26,9 +26,9 @@ LABEL summary="$SUMMARY" \
       io.openshift.expose-services="6379:redis" \
       io.openshift.tags="database,redis,redis5,rh-redis5" \
       com.redhat.component="rh-redis5-container" \
-      name="centos/redis-5-centos7" \
+      name="centos7/redis-5-centos7" \
       version="5" \
-      usage="podman run -d --name redis_database -p 6379:6379 centos/redis-5-centos7" \
+      usage="podman run -d --name redis_database -p 6379:6379 quay.io/centos7/redis-5-centos7" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 6379

--- a/5/root/usr/share/container-scripts/redis/README.md
+++ b/5/root/usr/share/container-scripts/redis/README.md
@@ -1,10 +1,10 @@
 Redis 5 in-memory data structure store container image
-====================
+======================================================
 
 This container image includes Redis 5 in-memory data structure store for OpenShift and general usage.
 Users can choose between RHEL, CentOS and Fedora based images.
 The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
-the CentOS images are available on [Docker Hub](https://hub.docker.com/r/centos/),
+the CentOS images are available on [Quay.io](https://quay.io/organization/centos7),
 and the Fedora images are available in [Fedora Registry](https://registry.fedoraproject.org/).
 The resulting image can be run using [podman](https://github.com/containers/libpod).
 
@@ -52,7 +52,7 @@ use a very strong password otherwise it will be very easy to break.**
 
 
 Environment variables and volumes
-----------------------------------
+---------------------------------
 
 **`REDIS_PASSWORD`**  
        Password for the server access

--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos/s2i-core-centos7
+FROM quay.io/centos7/s2i-core-centos7
 
 # Redis image based on Software Collections packages
 #
@@ -26,9 +26,9 @@ LABEL summary="$SUMMARY" \
       io.openshift.expose-services="6379:redis" \
       io.openshift.tags="database,redis,redis6,rh-redis6" \
       com.redhat.component="rh-redis6-container" \
-      name="centos/redis-6-centos7" \
+      name="centos7/redis-6-centos7" \
       version="6" \
-      usage="podman run -d --name redis_database -p 6379:6379 centos/redis-6-centos7" \
+      usage="podman run -d --name redis_database -p 6379:6379 quay.io/centos7/redis-6-centos7" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 6379

--- a/6/root/usr/bin/run-redis
+++ b/6/root/usr/bin/run-redis
@@ -9,7 +9,7 @@ set -eu
 # Process the Redis configuration files
 log_info 'Processing Redis configuration files ...'
 if [[ -v REDIS_PASSWORD ]]; then
-  envsubst < ${CONTAINER_SCRIPTS_PATH}/password.conf.template >> /etc/redis.conf
+  envsubst < ${CONTAINER_SCRIPTS_PATH}/password.conf.template >> /etc/redis/redis.conf
 else
   log_info 'WARNING: setting REDIS_PASSWORD is recommended'
 fi
@@ -24,4 +24,4 @@ fi
 unset_env_vars
 log_volume_info "${REDIS_DATADIR}"
 log_info 'Running final exec -- Only Redis logs after this point'
-exec ${REDIS_PREFIX}/bin/redis-server /etc/redis.conf --daemonize no "$@" 2>&1
+exec ${REDIS_PREFIX}/bin/redis-server /etc/redis/redis.conf --daemonize no "$@" 2>&1

--- a/6/root/usr/libexec/container-setup
+++ b/6/root/usr/libexec/container-setup
@@ -5,13 +5,13 @@ set -eu
 
 # setup config file
 if [ -n "${ENABLED_COLLECTIONS:-}" ] ; then
-  mv /etc/opt/rh/rh-redis6/redis.conf /etc/redis.conf
-  ln -s /etc/redis.conf /etc/opt/rh/rh-redis6/redis.conf
+  mv /etc/opt/rh/rh-redis6/redis.conf /etc/redis/redis.conf
+  ln -s /etc/redis/redis.conf /etc/opt/rh/rh-redis6/redis.conf
 fi
 
 # setup directory for data
-chown -R redis:0 "${HOME}" /etc/redis.conf
-restorecon -R "${HOME}" /etc/redis.conf
+chown -R redis:0 "${HOME}" /etc/redis/redis.conf
+restorecon -R "${HOME}" /etc/redis/redis.conf
 
 # create a symlink for SCL datadir, so there is some reasonable content there
 if [ -n "${ENABLED_COLLECTIONS:-}" ] ; then
@@ -24,8 +24,8 @@ fi
 # When only specifying user, group is 0, that's why /var/lib/redis must have
 # owner redis.0; that allows to avoid a+rwx for this dir
 chmod 0770 "${HOME}" "${REDIS_DATADIR}"
-chmod 0660 /etc/redis.conf
+chmod 0660 /etc/redis/redis.conf
 
 # adjust config with changes we do every-time
 clear_config
-envsubst < ${CONTAINER_SCRIPTS_PATH}/base.conf.template >> /etc/redis.conf
+envsubst < ${CONTAINER_SCRIPTS_PATH}/base.conf.template >> /etc/redis/redis.conf

--- a/6/root/usr/share/container-scripts/redis/README.md
+++ b/6/root/usr/share/container-scripts/redis/README.md
@@ -1,10 +1,10 @@
 Redis 6 in-memory data structure store container image
-====================
+======================================================
 
 This container image includes Redis 6 in-memory data structure store for OpenShift and general usage.
 Users can choose between RHEL, CentOS and Fedora based images.
 The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
-the CentOS images are available on [Docker Hub](https://hub.docker.com/r/centos/),
+the CentOS images are available on [Quay.io](https://quay.io/organization/centos7),
 and the Fedora images are available in [Fedora Registry](https://registry.fedoraproject.org/).
 The resulting image can be run using [podman](https://github.com/containers/libpod).
 

--- a/6/root/usr/share/container-scripts/redis/common.sh
+++ b/6/root/usr/share/container-scripts/redis/common.sh
@@ -22,5 +22,5 @@ function clear_config() {
       -e "s/^logfile/#logfile/" \
       -e "s/^dir /#dir /" \
       -e "/^protected-mode/s/yes/no/" \
-      -i /etc/redis.conf
+      -i /etc/redis/redis.conf
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 Redis container image
-==================
+=====================
+
+Redis 5 status:[![Docker Repository on Quay](https://quay.io/repository/centos7/redis-5-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/redis-5-centos7), Redis 6 status:
+[![Docker Repository on Quay](https://quay.io/repository/centos7/redis-6-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/redis-6-centos7)
 
 This repository contains Dockerfiles for Redis container image.
 Users can choose between RHEL, Fedora and CentOS based images.
@@ -11,7 +14,7 @@ For more information about concepts used in these container images, see the
 
 
 Versions
----------------
+--------
 Redis version currently provided are:
 * [redis-5](5)
 * [redis-6](6)
@@ -25,7 +28,7 @@ CentOS versions currently supported are:
 
 
 Installation
----------------
+------------
 To build a Redis image, choose either the CentOS or RHEL based image:
 *  **RHEL based image**
 
@@ -51,7 +54,7 @@ To build a Redis image, choose either the CentOS or RHEL based image:
     This image is available on DockerHub. To download it run:
 
     ```
-    $ podman pull centos/redis-5-centos7
+    $ podman pull quay.io/centos7/redis-5-centos7
     ```
 
     To build a Redis image from scratch run:
@@ -70,7 +73,7 @@ on all provided versions of Redis.**
 
 
 Usage
----------------------------------
+-----
 
 For information about usage of Dockerfile for Redis 5,
 see [usage documentation](5).
@@ -79,7 +82,7 @@ For information about usage of Dockerfile for Redis 6,
 see [usage documentation](6).
 
 Test
----------------------
+----
 Users can choose between testing a Redis test application based on a RHEL or CentOS image.
 
 *  **RHEL based image**

--- a/imagestreams/redis-centos.json
+++ b/imagestreams/redis-centos.json
@@ -73,7 +73,7 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/centos/redis-5-centos7:latest"
+          "name": "quay.io/centos7/redis-5-centos7:latest"
         },
         "referencePolicy": {
           "type": "Local"

--- a/test/run-openshift-local-cluster
+++ b/test/run-openshift-local-cluster
@@ -53,14 +53,13 @@ function check_redis_os_service_connection() {
 function test_redis_pure_image() {
   local image_name=$1
   local image_name_no_namespace=${image_name##*/}
-  local service_name=${image_name_no_namespace}
+  local service_name="${image_name_no_namespace%%:*}-testing"
 
   ct_os_new_project
-  ct_os_upload_image "${image_name}"
   # Create a specific imagestream tag for the image so that oc cannot use anything else
-  ct_os_upload_image "${image_name}" "$image_name_no_namespace:testing"
+  ct_os_upload_image "${image_name}" "$image_name_no_namespace"
 
-  ct_os_deploy_pure_image "$image_name_no_namespace:testing" \
+  ct_os_deploy_pure_image "$image_name_no_namespace" \
                           --name "${service_name}" \
                           --env REDIS_PASSWORD=pass
 
@@ -71,9 +70,9 @@ function test_redis_pure_image() {
 }
 
 function test_redis_template() {
-  local image_name=${1:-centos/redis-5-centos7}
+  local image_name=${1:-quay.io/centos7/redis-5-centos7}
   local image_name_no_namespace=${image_name##*/}
-  local service_name=${image_name_no_namespace}
+  local service_name="${image_name_no_namespace%%:*}-testing"
 
   ct_os_new_project
   ct_os_upload_image "${image_name}" "redis:$VERSION"

--- a/test/test-lib-redis.sh
+++ b/test/test-lib-redis.sh
@@ -30,7 +30,7 @@ function test_redis_imagestream() {
     *) echo "Imagestream testing not supported for $OS environment." ; return 0 ;;
   esac
 
-  ct_os_test_image_stream_template "${THISDIR}/../imagestreams/redis-${OS%[0-9]*}.json" "${THISDIR}/../examples/redis-ephemeral-template.json" redis "-p REDIS_VERSION=${VERSION}"
+  ct_os_test_image_stream_template "${THISDIR}/../imagestreams/redis-${OS%%[0-9]*}.json" "${THISDIR}/../examples/redis-ephemeral-template.json" redis "-p REDIS_VERSION=${VERSION}"
 }
 
 # vim: set tabstop=2:shiftwidth=2:expandtab:


### PR DESCRIPTION
This commit uses Quay.io register instead of Docker.io

Fixes: https://github.com/sclorg/redis-container/issues/69
