### PR TITLE
imagestream: prefer quay.io image

### DIFF
--- a/imagestreams/redis-centos.json
+++ b/imagestreams/redis-centos.json
@@ -55,7 +55,7 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/centos/redis-5-centos7:latest"
+          "name": "quay.io/centos7/redis-5-centos7:latest"
         },
         "referencePolicy": {
           "type": "Local"


### PR DESCRIPTION
Use quay.io in imagestreams to avoid hitting ratelimit on dockerhub