### PR TITLE
Update imagestreams for RHSCL 3.8

### DIFF
--- a/examples/redis-ephemeral-template.json
+++ b/examples/redis-ephemeral-template.json
@@ -1,6 +1,6 @@
 {
   "kind": "Template",
-  "apiVersion": "v1",
+  "apiVersion": "template.openshift.io/v1",
   "metadata": {
     "name": "redis-ephemeral",
     "annotations": {
@@ -63,7 +63,7 @@
     },
     {
       "kind": "DeploymentConfig",
-      "apiVersion": "v1",
+      "apiVersion": "apps.openshift.io/v1",
       "metadata": {
         "name": "${DATABASE_SERVICE_NAME}",
         "annotations": {

--- a/examples/redis-ephemeral-template.json
+++ b/examples/redis-ephemeral-template.json
@@ -208,8 +208,8 @@
     {
       "name": "REDIS_VERSION",
       "displayName": "Version of Redis Image",
-      "description": "Version of Redis image to be used (5-el7, 5-el8, or latest).",
-      "value": "5-el8",
+      "description": "Version of Redis image to be used (5-el7, 5-el8, 6-el7, 6-el8, or latest).",
+      "value": "6-el8",
       "required": true
     }
   ]

--- a/examples/redis-persistent-template.json
+++ b/examples/redis-persistent-template.json
@@ -1,6 +1,6 @@
 {
   "kind": "Template",
-  "apiVersion": "v1",
+  "apiVersion": "template.openshift.io/v1",
   "metadata": {
     "name": "redis-persistent",
     "annotations": {
@@ -80,7 +80,7 @@
     },
     {
       "kind": "DeploymentConfig",
-      "apiVersion": "v1",
+      "apiVersion": "apps.openshift.io/v1",
       "metadata": {
         "name": "${DATABASE_SERVICE_NAME}",
         "annotations": {

--- a/examples/redis-persistent-template.json
+++ b/examples/redis-persistent-template.json
@@ -232,8 +232,8 @@
     {
       "name": "REDIS_VERSION",
       "displayName": "Version of Redis Image",
-      "description": "Version of Redis image to be used (5-el7, 5-el8, or latest).",
-      "value": "5-el8",
+      "description": "Version of Redis image to be used (5-el7, 5-el8, 6-el7, 6-el8, or latest).",
+      "value": "6-el8",
       "required": true
     }
   ]

--- a/imagestreams/redis-centos.json
+++ b/imagestreams/redis-centos.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": "v1",
+  "apiVersion": "image.openshift.io/v1",
   "kind": "ImageStream",
   "metadata": {
     "annotations": {

--- a/imagestreams/redis-rhel-aarch64.json
+++ b/imagestreams/redis-rhel-aarch64.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": "v1",
+  "apiVersion": "image.openshift.io/v1",
   "kind": "ImageStream",
   "metadata": {
     "annotations": {

--- a/imagestreams/redis-rhel.json
+++ b/imagestreams/redis-rhel.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": "v1",
+  "apiVersion": "image.openshift.io/v1",
   "kind": "ImageStream",
   "metadata": {
     "annotations": {

--- a/imagestreams/redis-rhel.json
+++ b/imagestreams/redis-rhel.json
@@ -46,6 +46,24 @@
       },
       {
         "annotations": {
+          "description": "Provides a Redis 6 database on RHEL 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/redis-container/tree/master/6/README.md.",
+          "iconClass": "icon-redis",
+          "openshift.io/display-name": "Redis 6 (RHEL 7)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "tags": "redis",
+          "version": "6"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/rhscl/redis-6-rhel7:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        },
+        "name": "6-el7"
+      },
+      {
+        "annotations": {
           "description": "Provides a Redis 5 database on RHEL 8. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/redis-container/tree/master/5/README.md.",
           "iconClass": "icon-redis",
           "openshift.io/display-name": "Redis 5 (RHEL 8)",


### PR DESCRIPTION
- Update imagestreams for RHSCL 3.8
- Update examples to redis 6
- Use groupified apiVersion
