### PR TITLE
Remove Redis 5 RHEL imagestreams, add RHEL 9 imagestreams

### DIFF
--- a/imagestreams/redis-rhel-aarch64.json
+++ b/imagestreams/redis-rhel-aarch64.json
@@ -28,6 +28,24 @@
       },
       {
         "annotations": {
+          "description": "Provides a Redis 6 database on RHEL 9. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/redis-container/tree/master/6/README.md.",
+          "iconClass": "icon-redis",
+          "openshift.io/display-name": "Redis 6 (RHEL 9)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "tags": "redis",
+          "version": "6"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/rhel9/redis-6:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        },
+        "name": "6-el9"
+      },
+      {
+        "annotations": {
           "description": "Provides a Redis 6 database on RHEL 8. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/redis-container/tree/master/6/README.md.",
           "iconClass": "icon-redis",
           "openshift.io/display-name": "Redis 6 (RHEL 8)",

--- a/imagestreams/redis-rhel.json
+++ b/imagestreams/redis-rhel.json
@@ -28,6 +28,24 @@
       },
       {
         "annotations": {
+          "description": "Provides a Redis 6 database on RHEL 9. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/redis-container/tree/master/6/README.md.",
+          "iconClass": "icon-redis",
+          "openshift.io/display-name": "Redis 6 (RHEL 9)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "tags": "redis",
+          "version": "6"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/rhel9/redis-6:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        },
+        "name": "6-el9"
+      },
+      {
+        "annotations": {
           "description": "Provides a Redis 6 database on RHEL 8. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/redis-container/tree/master/6/README.md.",
           "iconClass": "icon-redis",
           "openshift.io/display-name": "Redis 6 (RHEL 8)",

--- a/imagestreams/redis-rhel.json
+++ b/imagestreams/redis-rhel.json
@@ -79,42 +79,6 @@
           "type": "Local"
         },
         "name": "6-el7"
-      },
-      {
-        "annotations": {
-          "description": "Provides a Redis 5 database on RHEL 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/redis-container/tree/master/5/README.md.",
-          "iconClass": "icon-redis",
-          "openshift.io/display-name": "Redis 5 (RHEL 7)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "tags": "redis",
-          "version": "5"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/rhscl/redis-5-rhel7:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        },
-        "name": "5-el7"
-      },
-      {
-        "annotations": {
-          "description": "Provides a Redis 5 database on RHEL 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/redis-container/tree/master/5/README.md.",
-          "iconClass": "icon-redis",
-          "openshift.io/display-name": "Redis 5",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "tags": "redis,hidden",
-          "version": "5"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/rhscl/redis-5-rhel7:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        },
-        "name": "5"
       }
     ]
   }


### PR DESCRIPTION
There do not seem to be any Redis 6 CentOS container builds though,
so 5 remains the only (albeit unmaintained) choice for OKD.

RHEL 7 Redis 5 retirement: Jun 2022
RHEL 8 Redis 5 retirement: May 2022

https://access.redhat.com/support/policy/updates/rhscl-rhel7
https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle
