### PR TITLE
Exit oc tests if login fails

### DIFF
--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -17,15 +17,15 @@ test_redis_integration
 test_redis_imagestream
 "
 
-set -u
-
 trap ct_os_cleanup EXIT SIGINT
 
 ct_os_set_ocp4
 
 ct_os_check_compulsory_vars
 
-oc status || false "It looks like oc is not properly logged in."
+ct_os_check_login || exit 1
+
+set -u
 
 # For testing on OpenShift 4 we use external registry
 export CT_EXTERNAL_REGISTRY=true


### PR DESCRIPTION
The nounset shell option needs to be set after the OC login attempt,
because (from man shopt):
```
-u
  If expansion is attempted on an unset  variable  or
  parameter,  the  shell prints  an  error  message, and, if not
  interactive exits with a non-zero status.
```
That is in this matter inconvenient, as we do not really know from the logs
what has happened if the oc login fails. Moreover the test suite ends
with success, as only the first failed test sets TESTSUITE_RESULT to 1.
If we check login with the ct_os_check_login function, it handles the
situation conveniently.
