### PR TITLE
Use RHEL-9.0.0 compose instead of RHEL-9.1.0 compose

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -46,7 +46,7 @@ jobs:
           - tmt_plan: "rhel9-docker"
             os_test: "rhel9"
             context: "RHEL9"
-            compose: "RHEL-9.1.0-Nightly"
+            compose: "RHEL-9.0.0-Nightly"
             api_key: "TF_INTERNAL_API_KEY"
             branch: "master"
             tmt_repo: "https://gitlab.cee.redhat.com/platform-eng-core-services/sclorg-tmt-plans"

--- a/.github/workflows/openshift-tests.yml
+++ b/.github/workflows/openshift-tests.yml
@@ -51,7 +51,7 @@ jobs:
           - tmt_plan: "rhel9-openshift-4"
             os_test: "rhel9"
             context: "RHEL9 - OpenShift 4"
-            compose: "RHEL-9.1.0-Nightly"
+            compose: "RHEL-9.0.0-Nightly"
             test_name: "test-openshift-4"
             api_key: "TF_INTERNAL_API_KEY"
             branch: "master"


### PR DESCRIPTION
subscription manager does not have RHEL-9.1.0 repos
but RHEL-9.0.0 already exists. Let's use it

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>