### PR TITLE
Use generic run tests

### DIFF
--- a/test/run
+++ b/test/run
@@ -134,7 +134,7 @@ function run_change_password_test() {
   check_result $?
   # The old password should not work anymore
   container_ip="$(get_container_ip testpass2)"
-  connection_works "$container_ip" foo
+  connection_works "$container_ip" bar
   check_result $?
 }
 

--- a/test/run
+++ b/test/run
@@ -228,8 +228,8 @@ run_doc_test() {
   # Extract the help.1 file from the container
   docker run --rm ${IMAGE_NAME} /bin/bash -c "cat /help.1" >${tmpdir}/help.1
   # Check whether the help.1 file includes some important information
-  for term in 6379 "REDIS\_PASSWORD" volume; do
-    if ! cat ${tmpdir}/help.1 | grep -F -q -e "${term}" ; then
+  for term in 6379 "REDIS.{1,2}PASSWORD" volume; do
+    if ! cat ${tmpdir}/help.1 | grep -E -q -e "${term}" ; then
       echo "ERROR: File /help.1 does not include '${term}'."
       return 1
     fi

--- a/test/run
+++ b/test/run
@@ -6,7 +6,6 @@
 # The image has to be available before this script is executed.
 #
 
-set -o errexit
 set -o nounset
 shopt -s nullglob
 
@@ -15,9 +14,6 @@ shopt -s nullglob
 test -n "${IMAGE_NAME-}" || { echo 'make sure $IMAGE_NAME is defined' && false ;}
 test -n "${VERSION-}" || { echo 'make sure $VERSION is defined' && false; }
 test -n "${OS-}" || { echo 'make sure $OS is defined' && false; }
-
-test_short_summary=''
-TESTSUITE_RESULT=0
 
 TEST_LIST="\
 run_container_creation_tests
@@ -29,40 +25,12 @@ run_change_password_test
 run_doc_test
 "
 
-CIDFILE_DIR=$(mktemp --suffix=redis_test_cidfiles -d)
+THISDIR=$(dirname ${BASH_SOURCE[0]})
+source "${THISDIR}"/test-lib.sh
 
-function cleanup() {
-  local cidfile
-  for cidfile in $CIDFILE_DIR/* ; do
-    local CONTAINER
-    CONTAINER=$(cat $cidfile)
+CID_FILE_DIR=$(mktemp --suffix=redis_test_cidfiles -d)
 
-    echo "Stopping and removing container $CONTAINER..."
-    docker stop $CONTAINER >/dev/null
-    local exit_status
-    exit_status=$(docker inspect -f '{{.State.ExitCode}}' $CONTAINER)
-    if [ "$exit_status" != "0" ]; then
-      echo "Inspecting container $CONTAINER"
-      docker inspect $CONTAINER
-      echo "Dumping logs for $CONTAINER"
-      docker logs $CONTAINER
-    fi
-    docker rm -v $CONTAINER >/dev/null
-    rm $cidfile
-    echo "Done."
-  done
-  rmdir $CIDFILE_DIR
-
-  echo "$test_short_summary"
-
-  if [ $TESTSUITE_RESULT -eq 0 ] ; then
-    echo "Tests for ${IMAGE_NAME} succeeded."
-  else
-    echo "Tests for ${IMAGE_NAME} failed."
-  fi
-  exit $TESTSUITE_RESULT
-}
-trap cleanup EXIT SIGINT
+ct_enable_cleanup
 
 check_result() {
   local result="$1"
@@ -74,7 +42,7 @@ check_result() {
 
 function get_cid() {
   local id="$1" ; shift || return 1
-  echo $(cat "$CIDFILE_DIR/$id")
+  echo $(cat "$CID_FILE_DIR/$id")
 }
 
 function get_container_ip() {
@@ -137,7 +105,7 @@ function test_redis() {
 
 function create_container() {
   local name=$1 ; shift
-  cidfile="$CIDFILE_DIR/$name"
+  cidfile="$CID_FILE_DIR/$name"
   # create container with a cidfile in a directory for cleanup
   local container_id
   [ "${DEBUG:-0}" -eq 1 ] && echo "DEBUG: docker run ${DOCKER_ARGS:-} --cidfile $cidfile -d \"$@\" $IMAGE_NAME ${CONTAINER_ARGS:-}" >&2
@@ -335,25 +303,5 @@ function run_tests_no_root_altuid() {
   DOCKER_ARGS="-u 12345" PASS=pass run_tests no_root_altuid
 }
 
-function run_all_tests() {
-  for test_case in $TEST_SET; do
-    echo "Running test $test_case ...."
-    TESTCASE_RESULT=0
-    $test_case
-    check_result $?
-    local test_msg
-    if [ $TESTCASE_RESULT -eq 0 ]; then
-      test_msg="[PASSED]"
-    else
-      test_msg="[FAILED]"
-      TESTSUITE_RESULT=1
-    fi
-    printf -v test_short_summary "%s %s for '%s' %s\n" "${test_short_summary}" "${test_msg}" "$test_case"
-    [ -n "${FAIL_QUICKLY:-}" ] && cleanup "${APP_NAME}" && return 1
-  done;
-}
-
-TEST_SET=${TESTS:-$TEST_LIST} run_all_tests
-
-echo "Success!"
-cleanup
+TEST_SUMMARY=''
+TEST_SET=${TESTS:-$TEST_LIST} ct_run_tests_from_testset "redis_tests"


### PR DESCRIPTION
In previous tests I see only results for:
```
 [PASSED] for 'run_container_creation_tests' 
 [PASSED] for 'run_tests_no_root' 
 [PASSED] for 'run_tests_no_pass' 
 [PASSED] for 'run_tests_no_pass_altuid' 
 [PASSED] for 'run_tests_no_root_altuid' 
```

Now all available tests are being executed:
```
 [PASSED] for 'redis_tests' run_container_creation_tests (00:00:00)
 [PASSED] for 'redis_tests' run_tests_no_root (00:00:04)
 [PASSED] for 'redis_tests' run_tests_no_pass (00:00:03)
 [PASSED] for 'redis_tests' run_tests_no_pass_altuid (00:00:03)
 [PASSED] for 'redis_tests' run_tests_no_root_altuid (00:00:04)
 [FAILED] for 'redis_tests' run_change_password_test (00:00:02)
 [PASSED] for 'redis_tests' run_doc_test (00:00:01)
```
However, I am not sure, why the `run_change_password_test` fails as it seems like it was not executed properly before. The failure should IMO not be connected to change in this PR.