### PR TITLE
deprecate redis6 Fedora image + move redis7 Fedora image to f38 base

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -22,14 +22,6 @@ jobs:
             quayio_token: "QUAY_IMAGE_SCLORG_BUILDER_TOKEN"
             docker_context: "6"
 
-          - dockerfile: "6/Dockerfile.fedora"
-            registry_namespace: "fedora"
-            tag: "fedora"
-            quayio_username: "QUAY_IMAGE_FEDORA_BUILDER_USERNAME"
-            quayio_token: "QUAY_IMAGE_FEDORA_BUILDER_TOKEN"
-            image_name: "redis-6"
-            docker_context: "6"
-
           - dockerfile: "7/Dockerfile.fedora"
             registry_namespace: "fedora"
             tag: "fedora"

--- a/7/Dockerfile.fedora
+++ b/7/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/s2i-core:37
+FROM quay.io/fedora/s2i-core:38
 
 # Redis image based on Software Collections packages
 #


### PR DESCRIPTION
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
