### PR TITLE
Fixes: #128 Add support for adding bind to /etc/redis.conf

### DIFF
--- a/6/root/usr/share/container-scripts/redis/README.md
+++ b/6/root/usr/share/container-scripts/redis/README.md
@@ -57,6 +57,9 @@ Environment variables and volumes
 **`REDIS_PASSWORD`**  
        Password for the server access
 
+**`BIND_ADDRESS`**
+       Configuration redis to listen on this address
+
 
 You can also set the following mount points by passing the `-v /host:/container:Z` flag to podman.
 

--- a/6/root/usr/share/container-scripts/redis/README.md
+++ b/6/root/usr/share/container-scripts/redis/README.md
@@ -58,7 +58,7 @@ Environment variables and volumes
        Password for the server access
 
 **`BIND_ADDRESS`**
-       Configuration redis to listen on this address
+       IP address for the server to listen on
 
 
 You can also set the following mount points by passing the `-v /host:/container:Z` flag to podman.

--- a/6/root/usr/share/container-scripts/redis/common.sh
+++ b/6/root/usr/share/container-scripts/redis/common.sh
@@ -24,3 +24,11 @@ function clear_config() {
       -e "/^protected-mode/s/yes/no/" \
       -i "${REDIS_CONF}"
 }
+
+function setup_bind_address() {
+  # Function sets bind
+  if [ -v BIND_ADDRESS ]; then
+    log_info "Configuring redis to listen on $BIND_ADDRESS only to ${REDIS_CONF}"
+    echo "bind $BIND_ADDRESS" >> "${REDIS_CONF}"
+  fi
+}

--- a/6/root/usr/share/container-scripts/redis/post-init.sh
+++ b/6/root/usr/share/container-scripts/redis/post-init.sh
@@ -4,3 +4,8 @@
 # Feel free to add content to this file or rewrite it at all.
 # You may also start redis server locally to load some data for example,
 # but do not forget to stop it after it, so it can be restarted after it.
+
+source "${CONTAINER_SCRIPTS_PATH}/common.sh"
+set -eu
+
+setup_bind_address

--- a/7/root/usr/share/container-scripts/redis/README.md
+++ b/7/root/usr/share/container-scripts/redis/README.md
@@ -57,7 +57,7 @@ Environment variables and volumes
        Password for the server access
 
 **`BIND_ADDRESS`**
-       Configuration redis to listen on this address
+       IP address for the server to listen on
 
 
 You can also set the following mount points by passing the `-v /host:/container:Z` flag to podman.

--- a/7/root/usr/share/container-scripts/redis/README.md
+++ b/7/root/usr/share/container-scripts/redis/README.md
@@ -56,6 +56,9 @@ Environment variables and volumes
 **`REDIS_PASSWORD`**  
        Password for the server access
 
+**`BIND_ADDRESS`**
+       Configuration redis to listen on this address
+
 
 You can also set the following mount points by passing the `-v /host:/container:Z` flag to podman.
 

--- a/7/root/usr/share/container-scripts/redis/common.sh
+++ b/7/root/usr/share/container-scripts/redis/common.sh
@@ -24,3 +24,11 @@ function clear_config() {
       -e "/^protected-mode/s/yes/no/" \
       -i "${REDIS_CONF}"
 }
+
+function setup_bind_address() {
+  # Function sets bind
+  if [[ -v BIND_ADDRESS ]]; then
+    log_info "Configuring redis to listen on $BIND_ADDRESS only ..."
+    echo "bind $BIND_ADDRESS" >> "${REDIS_CONF}"
+  fi
+}

--- a/7/root/usr/share/container-scripts/redis/post-init.sh
+++ b/7/root/usr/share/container-scripts/redis/post-init.sh
@@ -4,3 +4,8 @@
 # Feel free to add content to this file or rewrite it at all.
 # You may also start redis server locally to load some data for example,
 # but do not forget to stop it after it, so it can be restarted after it.
+
+source "${CONTAINER_SCRIPTS_PATH}/common.sh"
+set -eu
+
+setup_bind_address

--- a/test/run
+++ b/test/run
@@ -23,6 +23,8 @@ run_tests_no_pass_altuid
 run_tests_no_root_altuid
 run_change_password_test
 run_doc_test
+run_bind_address_test
+run_no_bind_address_test
 "
 
 THISDIR=$(dirname ${BASH_SOURCE[0]})
@@ -141,6 +143,25 @@ function assert_local_access() {
   docker exec $(ct_get_cid "$id") bash -c 'redis-cli ping'
 }
 
+
+function assert_bind_address() {
+  local name="$1"
+  REDIS_CONF=/etc/redis.conf
+  local run_cmd="[ -f $REDIS_CONF ] && grep \"^bind 127.0.0.1\" $REDIS_CONF"
+
+  echo "Checking if bind is set to 127.0.0.1 in $REDIS_CONF."
+  docker exec $(get_cid "$name") /bin/bash -c "${run_cmd}"
+}
+
+function assert_no_bind_address() {
+  local name="$1"
+  REDIS_CONF=/etc/redis.conf
+  local run_cmd="[ -f $REDIS_CONF ] && ! grep \"^bind 127.0.0.1\" $REDIS_CONF"
+
+  echo "Checking if bind is not set in $REDIS_CONF."
+  docker exec $(get_cid "$name") /bin/bash -c "${run_cmd}"
+}
+
 # Make sure the invocation of docker run fails.
 function assert_container_creation_fails() {
 
@@ -212,15 +233,27 @@ function run_tests() {
   create_container $name $envs
   ret=$?
   ct_check_testcase_result $ret
-  test_connection "$name" "$PASS"
-  ret=$?
-  ct_check_testcase_result $ret
   # Only check version on rhel/centos builds
   if [ "$OS" != "fedora" ]; then
     echo "  Testing scl usage"
-    test_scl_usage $name 'redis-server --version' "$VERSION"
+    test_scl_usage "$name" 'redis-server --version' "$VERSION"
     ct_check_testcase_result $?
   fi
+  if [ "$name" == "bind_address_test" ]; then
+    echo "   Testing bind_address test"
+    assert_bind_address "$name"
+    ct_check_testcase_result $?
+    # Quit test suite. redis container will not response. bind is set to localhost
+    return
+  fi
+  if [ "$name" == "no_bind_address_test" ]; then
+    echo "   Testing no bind_address test"
+    assert_no_bind_address "$name"
+    ct_check_testcase_result $?
+  fi
+  test_connection "$name" "$PASS"
+  ret=$?
+  ct_check_testcase_result $ret
   echo "  Testing login accesses"
   local container_ip
   container_ip=$(ct_get_cip $name)
@@ -262,6 +295,14 @@ function run_tests_no_pass_altuid() {
 function run_tests_no_root_altuid() {
   # Test with arbitrary uid for the container with password
   DOCKER_ARGS="-u 12345" PASS=pass run_tests no_root_altuid
+}
+
+function run_bind_address_test() {
+  DOCKER_ARGS="-e BIND_ADDRESS=127.0.0.1" run_tests bind_address_test
+}
+
+function run_no_bind_address_test() {
+  run_tests no_bind_address_test
 }
 
 ct_init

--- a/test/run
+++ b/test/run
@@ -146,20 +146,18 @@ function assert_local_access() {
 
 function assert_bind_address() {
   local name="$1"
-  REDIS_CONF=/etc/redis.conf
-  local run_cmd="[ -f $REDIS_CONF ] && grep \"^bind 127.0.0.1\" $REDIS_CONF"
+  local run_cmd="[ -f \${REDIS_CONF} ] && grep \"^bind 127.0.0.1\" \${REDIS_CONF}"
 
-  echo "Checking if bind is set to 127.0.0.1 in $REDIS_CONF."
-  docker exec $(get_cid "$name") /bin/bash -c "${run_cmd}"
+  echo "Checking if bind is set to 127.0.0.1 in redis.conf file."
+  docker exec $(ct_get_cid "$name") /bin/bash -c "${run_cmd}"
 }
 
 function assert_no_bind_address() {
   local name="$1"
-  REDIS_CONF=/etc/redis.conf
-  local run_cmd="[ -f $REDIS_CONF ] && ! grep \"^bind 127.0.0.1\" $REDIS_CONF"
+  local run_cmd="[ -f \${REDIS_CONF} ] && ! grep \"^bind 127.0.0.1\" \${REDIS_CONF}"
 
-  echo "Checking if bind is not set in $REDIS_CONF."
-  docker exec $(get_cid "$name") /bin/bash -c "${run_cmd}"
+  echo "Checking if bind is not set in redis.conf file."
+  docker exec $(ct_get_cid "$name") /bin/bash -c "${run_cmd}"
 }
 
 # Make sure the invocation of docker run fails.


### PR DESCRIPTION
Add support for adding bind to /etc/redis.conf
by BIND_ADDRESS variable

Closes #128

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
