### PR TITLE
Add support for testing the latest imagestreams

### DIFF
--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -15,6 +15,7 @@ source ${THISDIR}/test-lib-redis.sh
 TEST_LIST="\
 test_redis_integration
 test_redis_imagestream
+test_latest_imagestreams
 "
 
 trap ct_os_cleanup EXIT SIGINT

--- a/test/test-lib-redis.sh
+++ b/test/test-lib-redis.sh
@@ -38,4 +38,12 @@ function test_redis_imagestream() {
   ct_os_test_image_stream_template "${THISDIR}/imagestreams/redis-${OS%[0-9]*}.json" "${THISDIR}/examples/redis-ephemeral-template.json" redis "-p REDIS_VERSION=${VERSION}${tag}"
 }
 
+function test_latest_imagestreams() {
+  info "Testing the latest version in imagestreams"
+  # Switch to root directory of a container
+  pushd "${THISDIR}/../.." >/dev/null
+  ct_check_latest_imagestreams
+  popd >/dev/null
+}
+
 # vim: set tabstop=2:shiftwidth=2:expandtab:


### PR DESCRIPTION
This pull request adds support for testing the latest imagestreams for redis container.
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
