### PR TITLE
Add Pytests for testing redis in OpenShift 4

### DIFF
--- a/test/run-openshift-pytest
+++ b/test/run-openshift-pytest
@@ -10,4 +10,4 @@ THISDIR=$(dirname ${BASH_SOURCE[0]})
 
 git show -s
 
-cd "${THISDIR}" && python3 -m pytest --showlocals -vv test_redis_*.py
+cd "${THISDIR}" && python3 -m pytest -s -rxfapP --showlocals -vv test_redis_*.py

--- a/test/run-openshift-pytest
+++ b/test/run-openshift-pytest
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# IMAGE_NAME specifies a name of the candidate image used for testing.
+# The image has to be available before this script is executed.
+# VERSION specifies the major version of the MariaDB in format of X.Y
+# OS specifies RHEL version (e.g. OS=rhel7)
+#
+
+THISDIR=$(dirname ${BASH_SOURCE[0]})
+
+git show -s
+
+cd "${THISDIR}" && python3 -m pytest --showlocals -vv test_redis_*.py

--- a/test/test_redis_imagestream.py
+++ b/test/test_redis_imagestream.py
@@ -1,0 +1,49 @@
+import os
+import sys
+
+import pytest
+
+from container_ci_suite.openshift import OpenShiftAPI
+from container_ci_suite.utils import check_variables
+
+if not check_variables():
+    print("At least one variable from IMAGE_NAME, OS, SINGLE_VERSION is missing.")
+    sys.exit(1)
+
+
+VERSION = os.getenv("SINGLE_VERSION")
+IMAGE_NAME = os.getenv("IMAGE_NAME")
+OS = os.getenv("TARGET")
+TAGS = {
+    "rhel8": "-el8",
+    "rhel9": "-el9"
+}
+TAG = TAGS.get(OS, None)
+
+
+class TestRedisImagestreamTemplate:
+
+    def setup_method(self):
+        self.oc_api = OpenShiftAPI(pod_name_prefix="redis", version=VERSION)
+
+    def teardown_method(self):
+        self.oc_api.delete_project()
+
+    @pytest.mark.parametrize(
+        "template",
+        [
+            "redis-ephemeral-template.json",
+            "redis-persistent-template.json"
+        ]
+    )
+    def test_redis_imagestream_template(self, template):
+        os_name = ''.join(i for i in OS if not i.isdigit())
+        assert self.oc_api.deploy_image_stream_template(
+            imagestream_file=f"imagestreams/redis-{os_name}.json",
+            template_file=f"examples/{template}",
+            app_name=self.oc_api.pod_name_prefix,
+            openshift_args=[
+                f"REDIS_VERSION={VERSION}{TAG}"
+            ]
+        )
+        assert self.oc_api.is_pod_running(pod_name_prefix=self.oc_api.pod_name_prefix)

--- a/test/test_redis_imagestream_template.py
+++ b/test/test_redis_imagestream_template.py
@@ -1,0 +1,46 @@
+import os
+import sys
+
+import pytest
+
+from container_ci_suite.openshift import OpenShiftAPI
+from container_ci_suite.utils import check_variables
+
+if not check_variables():
+    print("At least one variable from IMAGE_NAME, OS, SINGLE_VERSION is missing.")
+    sys.exit(1)
+
+
+VERSION = os.getenv("SINGLE_VERSION")
+IMAGE_NAME = os.getenv("IMAGE_NAME")
+OS = os.getenv("TARGET")
+TAGS = {
+    "rhel8": "-el8",
+    "rhel9": "-el9"
+}
+TAG = TAGS.get(OS, None)
+
+
+class TestRedisImagestreamTemplate:
+
+    def setup_method(self):
+        self.oc_api = OpenShiftAPI(pod_name_prefix="redis", version=VERSION)
+
+    def teardown_method(self):
+        self.oc_api.delete_project()
+
+    @pytest.mark.parametrize(
+        "template",
+        [
+            "redis-ephemeral-template.json",
+            "redis-persistent-template.json"
+        ]
+    )
+    def test_redis_imagestream_template(self, template):
+        os_name = ''.join(i for i in OS if not i.isdigit())
+        assert self.oc_api.deploy_image_stream_template(
+            imagestream_file=f"imagestreams/redis-{os_name}.json",
+            template_file=f"examples/{template}",
+            app_name=self.oc_api.pod_name_prefix
+        )
+        assert self.oc_api.is_pod_running(pod_name_prefix=self.oc_api.pod_name_prefix)

--- a/test/test_redis_latest_imagestreams.py
+++ b/test/test_redis_latest_imagestreams.py
@@ -1,0 +1,26 @@
+import os
+import sys
+
+import pytest
+
+from pathlib import Path
+
+from container_ci_suite.imagestreams import ImageStreamChecker
+from container_ci_suite.utils import check_variables
+
+TEST_DIR = Path(os.path.abspath(os.path.dirname(__file__)))
+
+if not check_variables():
+    print("At least one variable from IMAGE_NAME, OS, SINGLE_VERSION is missing.")
+    sys.exit(1)
+
+
+class TestLatestImagestreams:
+
+    def setup_method(self):
+        self.isc = ImageStreamChecker(working_dir=TEST_DIR.parent)
+
+    def test_latest_imagestream(self):
+        self.latest_version = self.isc.get_latest_version()
+        assert self.latest_version != ""
+        self.isc.check_imagestreams(self.latest_version)

--- a/test/test_redis_template.py
+++ b/test/test_redis_template.py
@@ -1,0 +1,53 @@
+import os
+import sys
+
+import pytest
+
+from container_ci_suite.openshift import OpenShiftAPI
+from container_ci_suite.utils import check_variables
+
+if not check_variables():
+    print("At least one variable from IMAGE_NAME, OS, SINGLE_VERSION is missing.")
+    sys.exit(1)
+
+
+VERSION = os.getenv("SINGLE_VERSION")
+IMAGE_NAME = os.getenv("IMAGE_NAME")
+OS = os.getenv("TARGET")
+
+
+class TestRedisDeployTemplate:
+
+    def setup_method(self):
+        self.oc_api = OpenShiftAPI(pod_name_prefix="redis", version=VERSION)
+
+    def teardown_method(self):
+        self.oc_api.delete_project()
+
+    @pytest.mark.parametrize(
+        "template",
+        [
+            "redis-ephemeral-template.json",
+            "redis-persistent-template.json"
+        ]
+    )
+    def test_redist_template_inside_cluster(self, template):
+        short_version = VERSION.replace(".", "")
+        assert self.oc_api.deploy_template_with_image(
+            image_name=IMAGE_NAME,
+            template=f"examples/{template}",
+            name_in_template="redis",
+            openshift_args=[
+                f"REDIS_VERSION={VERSION}",
+                f"DATABASE_SERVICE_NAME={self.oc_api.pod_name_prefix}",
+                f"REDIS_PASSWORD=testp"
+            ]
+        )
+
+        assert self.oc_api.is_pod_running(pod_name_prefix=self.oc_api.pod_name_prefix)
+        assert self.oc_api.check_command_internal(
+            image_name=f"registry.redhat.io/{OS}/redis-{short_version}",
+            service_name=self.oc_api.pod_name_prefix,
+            cmd="timeout 15 redis-cli -h <IP> -a testp ping",
+            expected_output="PONG"
+        )


### PR DESCRIPTION
This pull request adds support for testing mariadb-container by PyTest.

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
