### PR TITLE
Remove RHEL-7 - EOL in June 2024

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ "6", "7" ]
-        os_test: [ "fedora", "rhel7", "rhel8", "rhel9", "c9s" ]
+        os_test: [ "fedora", "rhel8", "rhel9", "c9s" ]
         test_case: [ "container" ]
 
     if: |

--- a/.github/workflows/openshift-tests.yml
+++ b/.github/workflows/openshift-tests.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ "6", "7" ]
-        os_test: [ "rhel7", "rhel8", "rhel9"]
+        os_test: [ "rhel8", "rhel9"]
         test_case: [ "openshift-4" ]
 
     steps:

--- a/6/root/usr/share/container-scripts/redis/README.md
+++ b/6/root/usr/share/container-scripts/redis/README.md
@@ -4,7 +4,7 @@ Redis 6 in-memory data structure store container image
 This container image includes Redis 6 in-memory data structure store for OpenShift and general usage.
 Users can choose between RHEL, CentOS and Fedora based images.
 The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
-the CentOS images are available on [Quay.io](https://quay.io/organization/centos7),
+the CentOS Stream images are available on [Quay.io](https://quay.io/organization/sclorg),
 and the Fedora images are available in [Fedora Registry](https://quay.io/organization/fedora).
 The resulting image can be run using [podman](https://github.com/containers/libpod).
 
@@ -84,6 +84,5 @@ See also
 Dockerfile and other sources for this container image are available on
 https://github.com/sclorg/redis-container.
 In that repository you also can find another versions of Python environment Dockerfiles.
-Dockerfile for CentOS is called `Dockerfile`, Dockerfile for RHEL7 is called `Dockerfile.rhel7`,
-for RHEL8 it's `Dockerfile.rhel8`, for RHEL9 it's `Dockerfile.rhel9`,
+Dockerfile for RHEL8 it's `Dockerfile.rhel8`, for RHEL9 it's `Dockerfile.rhel9`,
 for CentOS Stream 9 it's `Dockerfile.c9s` and the Fedora Dockerfile is called Dockerfile.fedora.

--- a/7/root/usr/share/container-scripts/redis/README.md
+++ b/7/root/usr/share/container-scripts/redis/README.md
@@ -2,8 +2,9 @@ Redis 7 in-memory data structure store container image
 ======================================================
 
 This container image includes Redis 7 in-memory data structure store for OpenShift and general usage.
-Users can choose between RHEL, CentOS and Fedora based images.
+Users can choose between RHEL, CentOS Stream, and Fedora based images.
 The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
+the CentOS Stream images are available on [Quay.io](https://quay.io/organization/sclorg),
 and the Fedora images are available in [Fedora Registry](https://quay.io/organization/fedora).
 The resulting image can be run using [podman](https://github.com/containers/libpod).
 
@@ -83,6 +84,5 @@ See also
 Dockerfile and other sources for this container image are available on
 https://github.com/sclorg/redis-container.
 In that repository you also can find another versions of Python environment Dockerfiles.
-Dockerfile for CentOS is called `Dockerfile`, Dockerfile for RHEL7 is called `Dockerfile.rhel7`,
-for RHEL8 it's `Dockerfile.rhel8`, for RHEL9 it's `Dockerfile.rhel9`,
+Dockerfile for RHEL8 it's `Dockerfile.rhel8`, for RHEL9 it's `Dockerfile.rhel9`,
 for CentOS Stream 9 it's `Dockerfile.c9s` and the Fedora Dockerfile is called Dockerfile.fedora.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Redis version currently provided are:
 * [redis-7](7)
 
 RHEL versions currently supported are:
-* RHEL7
 * RHEL8
 * RHEL9
 
@@ -37,11 +36,11 @@ Installation
 To build a Redis image, choose either the CentOS or RHEL based image:
 *  **RHEL based image**
 
-    These images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/#/registry.access.redhat.com/rhscl/redis-6-rhel7).
+    These images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/#/registry.access.redhat.com/rhel8/redis-6).
     To download it run:
 
     ```
-    $ podman pull registry.access.redhat.com/rhscl/redis-6-rhel7
+    $ podman pull registry.access.redhat.com/rhel8/redis-6
     ```
 
     To build a RHEL based Redis image, you need to run the build on a properly
@@ -51,7 +50,7 @@ To build a Redis image, choose either the CentOS or RHEL based image:
     $ git clone --recursive https://github.com/sclorg/redis-container.git
     $ cd redis-container
     $ git submodule update --init
-    $ make build TARGET=rhel7 VERSIONS=6
+    $ make build TARGET=rhel8 VERSIONS=6
     ```
 
 *  **CentOS Stream based image**
@@ -83,19 +82,22 @@ Usage
 For information about usage of Dockerfile for Redis 6,
 see [usage documentation](6).
 
+For information about usage of Dockerfile for Redis 7,
+see [usage documentation](7).
+
 Test
 ----
 Users can choose between testing a Redis test application based on a RHEL or CentOS image.
 
 *  **RHEL based image**
 
-    To test a RHEL7 based Redis image, you need to run the test on a properly
+    To test a RHEL8 based Redis image, you need to run the test on a properly
     subscribed RHEL machine.
 
     ```
     $ cd redis-container
     $ git submodule update --init
-    $ make test TARGET=rhel7 VERSIONS=6
+    $ make test TARGET=rhel8 VERSIONS=6
     ```
 
 *  **CentOS Stream based image**

--- a/imagestreams/imagestreams.yaml
+++ b/imagestreams/imagestreams.yaml
@@ -17,9 +17,6 @@
   - filename: redis-rhel.json
     latest: "6-el8"
     distros:
-      - name: RHEL 7
-        app_versions: [6]
-
       - name: RHEL 8
         app_versions: [6]
 
@@ -29,9 +26,6 @@
   - filename: redis-rhel-aarch64.json
     latest: "6-el8"
     distros:
-      - name: RHEL 7
-        app_versions: [6]
-
       - name: RHEL 8
         app_versions: [6]
 

--- a/imagestreams/redis-rhel-aarch64.json
+++ b/imagestreams/redis-rhel-aarch64.json
@@ -10,24 +10,6 @@
   "spec": {
     "tags": [
       {
-        "name": "6-el7",
-        "annotations": {
-          "openshift.io/display-name": "Redis 6 (RHEL 7)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Provides a Redis 6 database on RHEL 7. For more information about using this database image, including OpenShift considerations, see  https://github.com/sclorg/redis-container/tree/master/6/README.md.",
-          "iconClass": "icon-redis",
-          "tags": "database,redis",
-          "version": "6"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/rhscl/redis-6-rhel7:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
         "name": "6-el8",
         "annotations": {
           "openshift.io/display-name": "Redis 6 (RHEL 8)",

--- a/imagestreams/redis-rhel.json
+++ b/imagestreams/redis-rhel.json
@@ -10,24 +10,6 @@
   "spec": {
     "tags": [
       {
-        "name": "6-el7",
-        "annotations": {
-          "openshift.io/display-name": "Redis 6 (RHEL 7)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Provides a Redis 6 database on RHEL 7. For more information about using this database image, including OpenShift considerations, see  https://github.com/sclorg/redis-container/tree/master/6/README.md.",
-          "iconClass": "icon-redis",
-          "tags": "database,redis",
-          "version": "6"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/rhscl/redis-6-rhel7:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
         "name": "6-el8",
         "annotations": {
           "openshift.io/display-name": "Redis 6 (RHEL 8)",

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -5,7 +5,7 @@
 # IMAGE_NAME specifies a name of the candidate image used for testing.
 # The image has to be available before this script is executed.
 # VERSION specifies the major version of the Redis in format of X.Y
-# OS specifies RHEL version (e.g. OS=rhel7)
+# OS specifies RHEL version (e.g. OS=rhel8)
 #
 
 THISDIR=$(dirname ${BASH_SOURCE[0]})

--- a/test/test-lib-redis.sh
+++ b/test/test-lib-redis.sh
@@ -14,11 +14,7 @@ source "${THISDIR}/test-lib-remote-openshift.sh"
 
 function test_redis_integration() {
   local service_name=redis
-  if [ "${OS}" == "rhel7" ]; then
-    namespace_image="rhscl/redis-${VERSION}-rhel7"
-  else
-    namespace_image="${OS}/redis-${VERSION}"
-  fi
+  namespace_image="${OS}/redis-${VERSION}"
   TEMPLATES="redis-ephemeral-template.json
   redis-persistent-template.json"
   for template in $TEMPLATES; do
@@ -35,13 +31,11 @@ function test_redis_integration() {
 # Check the imagestream
 function test_redis_imagestream() {
   if [ "${VERSION}" == "7" ] && [ "${OS}" != "rhel9" ]; then
-    echo "Skipping testing version. It is not available for RHEL 7 and RHEL 8."
+    echo "Skipping testing version. It is not available for RHEL 8."
     return 0
   fi
-  local tag="-el7"
-  if [ "${OS}" == "rhel8" ]; then
-    tag="-el8"
-  elif [ "${OS}" == "rhel9" ]; then
+  tag="-el8"
+  if [ "${OS}" == "rhel9" ]; then
     tag="-el9"
   fi
   TEMPLATES="redis-ephemeral-template.json


### PR DESCRIPTION
This pull request deprecates RHEL7 and updates README's
