### PR TITLE
Testing Helm charts in redis-container

### DIFF
--- a/test/test_redis_helm_chart_imagestreams.py
+++ b/test/test_redis_helm_chart_imagestreams.py
@@ -1,0 +1,62 @@
+import os
+
+import pytest
+from pathlib import Path
+
+from container_ci_suite.helm import HelmChartsAPI
+
+test_dir = Path(os.path.abspath(os.path.dirname(__file__)))
+
+
+class TestHelmRHELRedisImageStreams:
+
+    def setup_method(self):
+        package_name = "redis-imagestreams"
+        path = test_dir
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, remote=True)
+        self.hc_api.clone_helm_chart_repo(
+            repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
+            subdir="charts/redhat"
+        )
+
+    def teardown_method(self):
+        self.hc_api.delete_project()
+
+    @pytest.mark.parametrize(
+        "version,registry",
+        [
+            ("6-el8", "registry.redhat.io/rhel8/redis-6:latest"),
+            ("6-el9", "registry.redhat.io/rhel9/redis-6:latest"),
+        ],
+    )
+    def test_package_imagestream(self, version, registry):
+        assert self.hc_api.helm_package()
+        assert self.hc_api.helm_installation()
+        assert self.hc_api.check_imagestreams(version=version, registry=registry)
+
+
+class TestHelmCentOSRedisImagestreams:
+    def setup_method(self):
+        package_name = "redis-imagestreams"
+        path = test_dir
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, remote=True)
+        self.hc_api.clone_helm_chart_repo(
+            repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
+            subdir="charts/centos"
+        )
+
+    def teardown_method(self):
+        self.hc_api.delete_project()
+
+    @pytest.mark.parametrize(
+        "version,registry",
+        [
+            ("6-el8", "quay.io/sclorg/redis-6-c8s:latest"),
+            ("6-el9", "quay.io/sclorg/redis-6-c9s:latest"),
+            ("7-el9", "quay.io/sclorg/redis-7-c9s:latest"),
+        ]
+    )
+    def test_package_imagestream(self, version, registry):
+        assert self.hc_api.helm_package()
+        assert self.hc_api.helm_installation()
+        assert self.hc_api.check_imagestreams(version=version, registry=registry)

--- a/test/test_redis_helm_chart_template.py
+++ b/test/test_redis_helm_chart_template.py
@@ -1,0 +1,50 @@
+import os
+
+import pytest
+from pathlib import Path
+
+from container_ci_suite.helm import HelmChartsAPI
+
+test_dir = Path(os.path.abspath(os.path.dirname(__file__)))
+
+VERSION = os.getenv("VERSION")
+IMAGE_NAME = os.getenv("IMAGE_NAME")
+BRANCH_TO_TEST = "master"
+OS = os.getenv("OS")
+
+TAGS = {
+    "rhel8": "-el8",
+    "rhel9": "-el9"
+}
+
+TAG = TAGS.get(OS, None)
+
+
+class TestHelmRedisPersistent:
+
+    def setup_method(self):
+        package_name = "redis-persistent"
+        path = test_dir
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, remote=True)
+        self.hc_api.clone_helm_chart_repo(
+            repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
+            subdir="charts/redhat"
+        )
+
+    def teardown_method(self):
+        self.hc_api.delete_project()
+
+    def test_package_persistent_by_helm_chart_test(self):
+        self.hc_api.package_name = "redis-imagestreams"
+        self.hc_api.helm_package()
+        assert self.hc_api.helm_installation()
+        self.hc_api.package_name = "redis-persistent"
+        self.hc_api.helm_package()
+        assert self.hc_api.helm_installation(
+            values={
+                "redis_version": f"{VERSION}{TAG}",
+                "namespace": self.hc_api.namespace
+            }
+        )
+        assert self.hc_api.is_pod_running(pod_name_prefix="redis")
+        assert self.hc_api.test_helm_chart(expected_str=["PONG"])


### PR DESCRIPTION
This pull request enables testing Helm charts stored in https://github.com/sclorg/helm-charts.


