### PR TITLE
Fix helm charts name. prefix `redhat-` is needed.

### DIFF
--- a/test/test_redis_shared_helm_imagestreams.py
+++ b/test/test_redis_shared_helm_imagestreams.py
@@ -11,7 +11,7 @@ test_dir = Path(os.path.abspath(os.path.dirname(__file__)))
 class TestHelmRHELRedisImageStreams:
 
     def setup_method(self):
-        package_name = "redis-imagestreams"
+        package_name = "redhat-redis-imagestreams"
         path = test_dir
         self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
         self.hc_api.clone_helm_chart_repo(
@@ -23,13 +23,15 @@ class TestHelmRHELRedisImageStreams:
         self.hc_api.delete_project()
 
     @pytest.mark.parametrize(
-        "version,registry",
+        "version,registry,expected",
         [
-            ("6-el8", "registry.redhat.io/rhel8/redis-6:latest"),
-            ("6-el9", "registry.redhat.io/rhel9/redis-6:latest"),
+            ("6-el8", "registry.redhat.io/rhel8/redis-6:latest", True),
+            ("6-el9", "registry.redhat.io/rhel9/redis-6:latest", True),
+            ("7-el9", "registry.redhat.io/rhel9/redis-7:latest", True),
+            ("7-el8", "registry.redhat.io/rhel8/redis-7:latest", False),
         ],
     )
-    def test_package_imagestream(self, version, registry):
+    def test_package_imagestream(self, version, registry, expected):
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
-        assert self.hc_api.check_imagestreams(version=version, registry=registry)
+        assert self.hc_api.check_imagestreams(version=version, registry=registry) == expected

--- a/test/test_redis_shared_helm_template.py
+++ b/test/test_redis_shared_helm_template.py
@@ -23,9 +23,9 @@ TAG = TAGS.get(OS, None)
 class TestHelmRedisPersistent:
 
     def setup_method(self):
-        package_name = "redis-persistent"
+        package_name = "redhat-redis-persistent"
         path = test_dir
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, shared_cluster=True)
         self.hc_api.clone_helm_chart_repo(
             repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
             subdir="charts/redhat"
@@ -35,10 +35,10 @@ class TestHelmRedisPersistent:
         self.hc_api.delete_project()
 
     def test_package_persistent_by_helm_chart_test(self):
-        self.hc_api.package_name = "redis-imagestreams"
+        self.hc_api.package_name = "redhat-redis-imagestreams"
         self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
-        self.hc_api.package_name = "redis-persistent"
+        self.hc_api.package_name = "redhat-redis-persistent"
         self.hc_api.helm_package()
         assert self.hc_api.helm_installation(
             values={


### PR DESCRIPTION
We use prefix `redhat-` in helm charts


<!-- issue-commentator = {"comment-id":"2658779343"} -->







































































<!-- testing-farm = {"lock":"false","comment-id":"2658791626","data":[{"id":"8a3af9b9-903f-40d2-8200-f9ec946aefd3","name":"Fedora - 7","status":"complete","outcome":"passed","runTime":342.242376,"created":"2025-02-14T09:50:39.877203","updated":"2025-02-14T09:50:39.877210","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8a3af9b9-903f-40d2-8200-f9ec946aefd3\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8a3af9b9-903f-40d2-8200-f9ec946aefd3/pipeline.log\">pipeline</a>"]},{"id":"78cc1605-1289-4072-bec6-5598d8354c11","name":"CentOS Stream 9 - 6","status":"complete","outcome":"passed","runTime":483.910369,"created":"2025-02-14T09:50:39.758263","updated":"2025-02-14T09:50:39.758270","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/78cc1605-1289-4072-bec6-5598d8354c11\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/78cc1605-1289-4072-bec6-5598d8354c11/pipeline.log\">pipeline</a>"]},{"id":"6e7e5f88-09d0-4516-af00-97ead19dd2c2","name":"CentOS Stream 9 - 7","status":"complete","outcome":"passed","runTime":486.343719,"created":"2025-02-14T09:50:37.016502","updated":"2025-02-14T09:50:37.016511","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/6e7e5f88-09d0-4516-af00-97ead19dd2c2\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/6e7e5f88-09d0-4516-af00-97ead19dd2c2/pipeline.log\">pipeline</a>"]},{"id":"1600f54e-adce-4b35-a6f7-599fa3b01d0d","name":"RHEL9 - 6","status":"complete","outcome":"passed","runTime":714.387564,"created":"2025-02-14T09:50:38.091849","updated":"2025-02-14T09:50:38.091855","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1600f54e-adce-4b35-a6f7-599fa3b01d0d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1600f54e-adce-4b35-a6f7-599fa3b01d0d/pipeline.log\">pipeline</a>"]},{"id":"10f3ef67-db04-477f-bccb-ff45dfe311e4","name":"RHEL9 - 7","status":"complete","outcome":"passed","runTime":739.909441,"created":"2025-02-14T09:50:37.683863","updated":"2025-02-14T09:50:37.683875","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/10f3ef67-db04-477f-bccb-ff45dfe311e4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/10f3ef67-db04-477f-bccb-ff45dfe311e4/pipeline.log\">pipeline</a>"]},{"id":"fe3b4ec0-87ab-46db-9eeb-9af12b1d23a4","name":"RHEL9 - OpenShift 4 - 7","status":"complete","outcome":"passed","runTime":842.055548,"created":"2025-02-14T09:50:54.063727","updated":"2025-02-14T09:50:54.063735","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/fe3b4ec0-87ab-46db-9eeb-9af12b1d23a4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/fe3b4ec0-87ab-46db-9eeb-9af12b1d23a4/pipeline.log\">pipeline</a>"]},{"id":"3604d02d-a13b-4436-861d-fad00f09953c","name":"RHEL9 - OpenShift 4 - 6","status":"complete","outcome":"passed","runTime":902.707295,"created":"2025-02-14T09:50:52.344432","updated":"2025-02-14T09:50:52.344438","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3604d02d-a13b-4436-861d-fad00f09953c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3604d02d-a13b-4436-861d-fad00f09953c/pipeline.log\">pipeline</a>"]},{"id":"d5fbf1a4-5169-42fe-bf96-7784f126fd70","name":"RHEL9 - PyTest - OpenShift 4 - 7","status":"complete","outcome":"passed","runTime":960.842975,"created":"2025-02-14T09:50:56.953932","updated":"2025-02-14T09:50:56.953938","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d5fbf1a4-5169-42fe-bf96-7784f126fd70\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d5fbf1a4-5169-42fe-bf96-7784f126fd70/pipeline.log\">pipeline</a>"]},{"id":"92468f5d-a8f0-46ac-ba37-a571252ab8ba","name":"RHEL8 - 6","status":"complete","outcome":"passed","runTime":994.748667,"created":"2025-02-14T09:50:39.474082","updated":"2025-02-14T09:50:39.474088","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/92468f5d-a8f0-46ac-ba37-a571252ab8ba\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/92468f5d-a8f0-46ac-ba37-a571252ab8ba/pipeline.log\">pipeline</a>"]},{"id":"d476852a-6089-46a1-98b4-15c536086c9b","name":"RHEL9 - PyTest - OpenShift 4 - 6","status":"complete","outcome":"passed","runTime":978.207906,"created":"2025-02-14T09:50:54.469262","updated":"2025-02-14T09:50:54.469268","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d476852a-6089-46a1-98b4-15c536086c9b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d476852a-6089-46a1-98b4-15c536086c9b/pipeline.log\">pipeline</a>"]},{"id":"69da4a3e-0e88-4667-9038-312a3f6ce325","name":"RHEL8 - OpenShift 4 - 6","status":"complete","outcome":"passed","runTime":1156.201638,"created":"2025-02-14T09:50:50.752420","updated":"2025-02-14T09:50:50.752426","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/69da4a3e-0e88-4667-9038-312a3f6ce325\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/69da4a3e-0e88-4667-9038-312a3f6ce325/pipeline.log\">pipeline</a>"]},{"id":"40ee271f-8296-424e-ba7d-1a14e4bb69b5","name":"RHEL8 - PyTest - OpenShift 4 - 6","runTime":1268.786022,"created":"2025-02-14T09:50:55.493991","updated":"2025-02-14T09:50:55.493998","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/40ee271f-8296-424e-ba7d-1a14e4bb69b5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/40ee271f-8296-424e-ba7d-1a14e4bb69b5/pipeline.log\">pipeline</a>"]}]} -->