### PR TITLE
Fix regular expression used for proper imagestream

### DIFF
--- a/test/test-lib-redis.sh
+++ b/test/test-lib-redis.sh
@@ -41,7 +41,7 @@ function test_redis_imagestream() {
   TEMPLATES="redis-ephemeral-template.json
   redis-persistent-template.json"
   for template in $TEMPLATES; do
-    ct_os_test_image_stream_template "${THISDIR}/imagestreams/redis-${OS%[0-9]*}.json" "${THISDIR}/examples/${template}" redis "-p REDIS_VERSION=${VERSION}${tag}"
+    ct_os_test_image_stream_template "${THISDIR}/imagestreams/redis-${OS//[0-9]/}.json" "${THISDIR}/examples/${template}" redis "-p REDIS_VERSION=${VERSION}${tag}"
   done
 }
 


### PR DESCRIPTION
Fix regular expression used for proper imagestream

rhel9 works fine.
For rhel10 it returns rhel1 that is wrong.

Allow also checking imagestreams for rhel10. The file is redis-rhel.json and not redis-rhel1.json
