### PR TITLE
Remove help test

### DIFF
--- a/test/run
+++ b/test/run
@@ -22,7 +22,6 @@ run_tests_no_pass
 run_tests_no_pass_altuid
 run_tests_no_root_altuid
 run_change_password_test
-run_doc_test
 run_bind_address_test
 run_no_bind_address_test
 "
@@ -216,11 +215,6 @@ test_scl_usage() {
     echo "ERROR[exec /bin/sh -ic "${run_cmd}"] Expected '${expected}', got '${out}'"
     return 1
   fi
-}
-
-run_doc_test() {
-  ct_doc_content_old 6379 "REDIS.*PASSWORD" volume
-  return $?
 }
 
 function run_tests() {


### PR DESCRIPTION
Let's remove doc test as help.1 is not generated at all.

See https://redhat.atlassian.net/browse/RHELMISC-27557
PR: https://github.com/sclorg/container-common-scripts/pull/421

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a subproject dependency with no functional code changes.
  * Removed a documentation-related test step from the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- issue-commentator = {"comment-id":"4068319926"} -->

<!-- testing-farm = {"lock":"false","comment-id":"4068606387","data":[{"id":"8cd18acc-231a-4f14-9ba2-9c8cd7260e21","name":"RHEL9 - PyTest - 7","status":"complete","outcome":"passed","runTime":1612.616639,"created":"2026-03-16T15:12:24.672633","updated":"2026-03-16T15:12:24.672640","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8cd18acc-231a-4f14-9ba2-9c8cd7260e21\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8cd18acc-231a-4f14-9ba2-9c8cd7260e21/pipeline.log\">pipeline</a>"]},{"id":"90431872-ab0f-46dc-abb3-457c00134df7","name":"RHEL9 - 7","status":"complete","outcome":"passed","runTime":962.07403,"created":"2026-03-16T15:31:17.655554","updated":"2026-03-16T15:31:17.655560","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/90431872-ab0f-46dc-abb3-457c00134df7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/90431872-ab0f-46dc-abb3-457c00134df7/pipeline.log\">pipeline</a>"]},{"id":"46412065-c9ae-4e9c-a31a-e6b781312b9f","name":"Fedora - 7","status":"complete","outcome":"passed","runTime":1702.098028,"created":"2026-03-16T15:22:50.980845","updated":"2026-03-16T15:22:50.980855","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/46412065-c9ae-4e9c-a31a-e6b781312b9f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/46412065-c9ae-4e9c-a31a-e6b781312b9f/pipeline.log\">pipeline</a>"]},{"id":"19af8092-ff88-43ea-87cb-0276777a4c08","name":"RHEL9 - Unsubscribed host - PyTest - 7","status":"complete","outcome":"passed","runTime":920.069621,"created":"2026-03-16T15:40:57.222617","updated":"2026-03-16T15:40:57.222626","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/19af8092-ff88-43ea-87cb-0276777a4c08\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/19af8092-ff88-43ea-87cb-0276777a4c08/pipeline.log\">pipeline</a>"]},{"id":"f0e57230-298a-4325-9735-ecf85f157a82","name":"CentOS Stream 9 - PyTest - 7","status":"complete","outcome":"passed","runTime":636.317244,"created":"2026-03-16T16:56:05.955505","updated":"2026-03-16T16:56:05.955512","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f0e57230-298a-4325-9735-ecf85f157a82\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f0e57230-298a-4325-9735-ecf85f157a82/pipeline.log\">pipeline</a>"]},{"id":"76e16793-62ae-4b51-b270-b52470e74456","name":"CentOS Stream 9 - 7","status":"complete","outcome":"passed","runTime":690.019681,"created":"2026-03-16T17:08:01.697473","updated":"2026-03-16T17:08:01.697480","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/76e16793-62ae-4b51-b270-b52470e74456\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/76e16793-62ae-4b51-b270-b52470e74456/pipeline.log\">pipeline</a>"]},{"id":"42034b1f-2d5b-4e68-af46-663b3ead20b9","name":"RHEL9 - Unsubscribed host - 7","status":"complete","outcome":"passed","runTime":1072.34785,"created":"2026-03-16T17:06:13.225214","updated":"2026-03-16T17:06:13.225222","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/42034b1f-2d5b-4e68-af46-663b3ead20b9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/42034b1f-2d5b-4e68-af46-663b3ead20b9/pipeline.log\">pipeline</a>"]},{"id":"2a642147-d5be-46c0-8111-d3c12a13144b","name":"Fedora - PyTest - 7","status":"complete","outcome":"passed","runTime":636.040387,"created":"2026-03-16T17:14:16.744315","updated":"2026-03-16T17:14:16.744323","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2a642147-d5be-46c0-8111-d3c12a13144b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2a642147-d5be-46c0-8111-d3c12a13144b/pipeline.log\">pipeline</a>"]},{"id":"12de05f7-3908-4b80-8cfe-849635b7b80a","name":"RHEL8 - PyTest - 6","status":"complete","outcome":"passed","runTime":757.626719,"created":"2026-03-16T17:13:52.587983","updated":"2026-03-16T17:13:52.587990","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/12de05f7-3908-4b80-8cfe-849635b7b80a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/12de05f7-3908-4b80-8cfe-849635b7b80a/pipeline.log\">pipeline</a>"]},{"id":"446afb6a-d88f-4400-8978-f6641f5ee982","name":"RHEL8 - 6","runTime":740.037464,"created":"2026-03-16T17:14:06.954375","updated":"2026-03-16T17:14:06.954381","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/446afb6a-d88f-4400-8978-f6641f5ee982\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/446afb6a-d88f-4400-8978-f6641f5ee982/pipeline.log\">pipeline</a>"]}]} -->